### PR TITLE
Small typo fix in Readme. submodules -> submodule .

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Here are the explanations of the steps:
 * You also need jsCoq's version of CodeMirror:
 
   ```
-  $ git submodules update --remote
+  $ git submodule update --remote
   $ cd ui-external/CodeMirror && npm install
   ```
 


### PR DESCRIPTION
git has no command 'submodules' rather the instruction should be 'git submodule update --remote' . :smile: 