### PR TITLE
Inspect command implementation

### DIFF
--- a/coq-js/icoq.ml
+++ b/coq-js/icoq.ml
@@ -123,6 +123,11 @@ let pp_of_goals ~doc sid : Pp.t option =
 
 (* Inspection subroutines *)
 
+let inspect_globals ?(env=Global.env ()) () =
+  let global_consts = seq_of_list @@
+      Environ.fold_constants (fun name _ l -> name :: l) env [] in
+  global_consts |> Seq.map Names.Constant.user
+
 let libobj_is_leaf obj =
   match obj with
   | Lib.Leaf _ -> true | _ -> false [@@warning "-4"]

--- a/coq-js/icoq.ml
+++ b/coq-js/icoq.ml
@@ -120,10 +120,23 @@ let pp_of_goals ~doc sid : Pp.t option =
   end
   with Proof_global.NoCurrentProof -> None
 
+let context_of_st m = match m with
+  | `Valid (Some st) ->
+    begin try
+        Pfedit.get_current_context ~p:(Proof_global.proof_of_state st.Vernacstate.proof) ()
+      with Proof_global.NoCurrentProof ->
+        Pfedit.get_current_context ()
+    end
+  | _ ->
+    let env = Global.env () in Evd.from_env env, env
+
+let context_of_stm ~doc sid =
+  let st = Stm.state_of_id ~doc sid in
+  context_of_st st
 
 (* Inspection subroutines *)
 
-let inspect_globals ?(env=Global.env ()) () =
+let inspect_globals ~env () =
   let global_consts = seq_of_list @@
       Environ.fold_constants (fun name _ l -> name :: l) env [] in
   global_consts |> Seq.map Names.Constant.user
@@ -137,7 +150,7 @@ let has_constant env kn =
     ignore @@ Environ.lookup_constant (Names.Constant.make1 kn) env; true
   with Not_found -> false
 
-let inspect_library ?(env=Global.env ()) () =
+let inspect_library ~env () =
   let ls = Lib.contents () in
   Seq.flat_map (fun ((_, kn), obj) -> seq_of_opt @@
     if libobj_is_leaf obj && has_constant env kn then Some kn
@@ -146,7 +159,7 @@ let inspect_library ?(env=Global.env ()) () =
 
 let default_mod_path = Names.ModPath.MPfile Names.DirPath.empty
 
-let inspect_locals ?(env=Global.env ()) ?(mod_path=default_mod_path) () =
+let inspect_locals ~env ?(mod_path=default_mod_path) () =
   let make_kername id = Names.KerName.make2 mod_path (Names.Label.of_id id) in
   let named_ctx = Environ.named_context env in
   seq_of_list (Context.Named.to_vars named_ctx |> Names.Id.Set.elements) |>

--- a/coq-js/icoq.mli
+++ b/coq-js/icoq.mli
@@ -54,6 +54,7 @@ val version : string * string * string * string * int
 (** [pp_of_goals ~doc sid] returns a pp representing the current goals  *)
 val pp_of_goals : doc:Stm.doc -> Stateid.t -> Pp.t option
 
+val inspect_globals : ?env:Environ.env -> unit -> Names.KerName.t seq
 val inspect_library : ?env:Environ.env -> unit -> Names.KerName.t seq
 val inspect_locals : ?env:Environ.env -> ?mod_path:Names.ModPath.t -> unit -> Names.KerName.t seq
 

--- a/coq-js/icoq.mli
+++ b/coq-js/icoq.mli
@@ -54,9 +54,11 @@ val version : string * string * string * string * int
 (** [pp_of_goals ~doc sid] returns a pp representing the current goals  *)
 val pp_of_goals : doc:Stm.doc -> Stateid.t -> Pp.t option
 
-val inspect_globals : ?env:Environ.env -> unit -> Names.KerName.t seq
-val inspect_library : ?env:Environ.env -> unit -> Names.KerName.t seq
-val inspect_locals : ?env:Environ.env -> ?mod_path:Names.ModPath.t -> unit -> Names.KerName.t seq
+val context_of_stm : doc:Stm.doc -> Stateid.t -> (Evd.evar_map * Environ.env)
+
+val inspect_globals : env:Environ.env -> unit -> Names.KerName.t seq
+val inspect_library : env:Environ.env -> unit -> Names.KerName.t seq
+val inspect_locals  : env:Environ.env -> ?mod_path:Names.ModPath.t -> unit -> Names.KerName.t seq
 
 (** [set_debug t] enables/disables debug mode  *)
 val set_debug : bool -> unit

--- a/coq-js/jscoq.js
+++ b/coq-js/jscoq.js
@@ -64,11 +64,11 @@ class CoqWorker {
         return rid;
     }
 
-    inspect(rid, search_query) {
+    inspect(sid, rid, search_query) {
         if (typeof search_query == 'undefined') { search_query = rid; rid = undefined; }
         if (typeof rid == 'undefined')
             rid = this._gen_rid = (this._gen_rid || 0) + 1;
-        this.sendCommand(["Inspect", rid, search_query]);
+        this.sendCommand(["Inspect", sid, rid, search_query]);
         return rid;
     }
 
@@ -125,9 +125,9 @@ class CoqWorker {
             rid = this.query(sid, rid, query));
     }
 
-    inspectPromise(rid, search_query) {
+    inspectPromise(sid, rid, search_query) {
         return this._wrapWithPromise(
-            this.inspect(rid, search_query));
+            this.inspect(sid, rid, search_query));
     }
 
     _wrapWithPromise(rid) {

--- a/coq-js/jscoq_worker.ml
+++ b/coq-js/jscoq_worker.ml
@@ -169,11 +169,6 @@ let update_loadpath (msg : lib_event) : unit =
 let process_lib_event (msg : lib_event) : unit =
   update_loadpath msg ; post_lib_event msg
 
-let rec seq_append s1 s2 =  (* use batteries?? *)
-  match s1 () with
-  | Seq.Nil -> s2
-  | Seq.Cons (x, xs) -> fun () -> Seq.Cons (x, seq_append xs s2)
-
 (* set_opts  : general options *)
 (* lib_init  : list of modules to load *)
 (* lib_path  : list of load paths *)
@@ -215,6 +210,8 @@ let coq_exn_info exn =
     let pp_exn    = Pp.opt @@ CErrors.iprint (e, info) in
     CoqExn (Loc.get_loc info, Stateid.get info, pp_exn)
 
+(* -- Used by Add command -- *)
+
 let requires ast =
   match ast with
   | Vernacexpr.VernacExpr (_, Vernacexpr.VernacRequire (prefix, _export, module_refs)) ->
@@ -225,6 +222,59 @@ let requires ast =
     Some ((prefix_str, module_refs_str))
   | _ -> None
   [@@warning "-4"]
+
+(* -- Used by Inspect command --*)
+
+let string_contains s1 s2 =  (* from Rosetta Code *)
+  let len1 = String.length s1
+  and len2 = String.length s2 in
+  if len1 < len2 then false else
+    let rec aux i =
+      (i >= 0) && ((String.sub s1 i len2 = s2) || aux (pred i))
+    in
+    aux (len1 - len2)
+
+let rec list_take n list =
+  if n > 0 then
+    match list with
+    | [] -> []
+    | x :: xs -> x :: (list_take (n - 1) xs)
+  else []
+  
+let list_starts_with l1 l2 = list_take (List.length l2) l1 = l2
+
+let rec seq_append s1 s2 =  (* use batteries?? *)
+  match s1 () with
+  | Seq.Nil -> s2
+  | Seq.Cons (x, xs) -> fun () -> Seq.Cons (x, seq_append xs s2)
+
+let rec prefix_of_modpath mp =
+  match mp with
+  | Names.ModPath.MPfile dp ->
+    List.rev_map Names.Id.to_string (Names.DirPath.repr dp) 
+  | Names.ModPath.MPdot (mp, last) ->
+    prefix_of_modpath mp @ [Names.Label.to_string last]
+  | Names.ModPath.MPbound _ -> [] (* XXX *)
+
+let modpath_starts_with mp prefix =
+  list_starts_with (prefix_of_modpath mp) prefix
+
+let is_within kn prefix =
+  modpath_starts_with (Names.KerName.modpath kn) prefix
+
+let symbols_for (q : search_query) env =
+    match q with
+    | Locals       -> Icoq.inspect_locals  ~env ()
+    | CurrentFile  -> seq_append (Icoq.inspect_library ~env ())
+                                 (Icoq.inspect_locals  ~env ())
+    | _            -> Icoq.inspect_globals ~env () 
+    [@@warning "-4"]
+
+let rec filter_by (q : search_query) =
+  match q with
+  | All | CurrentFile | Locals -> (fun _ -> true)
+  | ModulePrefix prefix -> (fun nm -> is_within nm prefix)
+  | Keyword s -> (fun nm -> string_contains (Names.KerName.to_string nm) s)
 
 let jscoq_execute =
   let out_fn = post_answer in fun doc -> function
@@ -271,12 +321,11 @@ let jscoq_execute =
       out_fn @@ Feedback { doc_id = 0; span_id = sid; route = rid; contents = Incomplete }
     end
 
-  | Inspect (rid, _q) ->
-    let env = Global.env () in
-    let symbols = seq_append (Icoq.inspect_library ~env ())
-                             (Icoq.inspect_locals ~env ()) in
-    (* TODO query is ignored for the time being *)
-    out_fn @@ SearchResults (rid, symbols)
+  | Inspect (rid, q) ->
+    let env = Global.env () in  (* TODO use local env, when in proof state? *)
+    let symbols = symbols_for q env in
+    let results = Seq.filter (filter_by q) symbols in
+    out_fn @@ SearchResults (rid, results)
 
   | Register file_path  ->
     Jslibmng.register_cma ~file_path

--- a/coq-js/jscoq_worker.ml
+++ b/coq-js/jscoq_worker.ml
@@ -53,7 +53,7 @@ type jscoq_cmd =
 
   | Goals   of Stateid.t
   | Query   of Stateid.t * Feedback.route_id * string
-  | Inspect of Feedback.route_id * search_query
+  | Inspect of Stateid.t * Feedback.route_id * search_query
 
   (*            filename   content *)
   | Register of string
@@ -321,8 +321,9 @@ let jscoq_execute =
       out_fn @@ Feedback { doc_id = 0; span_id = sid; route = rid; contents = Incomplete }
     end
 
-  | Inspect (rid, q) ->
-    let env = Global.env () in  (* TODO use local env, when in proof state? *)
+  | Inspect (sid, rid, q) ->
+    let sid = if Stateid.to_int sid == 0 then Jscoq_doc.tip !doc else sid in
+    let _, env = Icoq.context_of_stm ~doc:(fst !doc) sid in
     let symbols = symbols_for q env in
     let results = Seq.filter (filter_by q) symbols in
     out_fn @@ SearchResults (rid, results)

--- a/coq-libjs/str.js
+++ b/coq-libjs/str.js
@@ -1,4 +1,4 @@
-function str_ll(s) { if (v_log) console.warn(s); }
+function str_ll(s, args) { if (str_ll.log) console.warn(s, args); }
 str_ll.log = true;
 
 //Provides: str_ll
@@ -9,7 +9,7 @@ var str_ll;
 function re_string_match() {
   // external re_string_match : regexp -> string -> int -> bool
   if (!re_string_match.warned) {
-    str_ll("Danger: missing primitive re_string_match called from Str");
+    str_ll("(from Str) re_string_match", arguments);
     re_string_match.warned = true;
   }
   return false;
@@ -20,18 +20,21 @@ function re_string_match() {
 function re_search_forward() {
   // external re_search_forward: regexp -> string -> int -> int array
   if (!re_search_forward.warned) {
-    str_ll("Danger: missing primitive re_search_forward called from Str");
+    str_ll("(from Str) re_search_forward", arguments);
     re_search_forward.warned = true;
   }
-  return [];
+  return [0]; /* [||] : int array */
 }
 
 //Provides: re_partial_match
 //Requires: str_ll
-function re_partial_match()          { str_ll('re_partial_match', arguments); }
+// external re_partial_match: regexp -> string -> int -> int array
+function re_partial_match()          { str_ll('re_partial_match', arguments);     return [0]; }
 //Provides: re_replacement_text
 //Requires: str_ll
-function re_replacement_text()       { str_ll('re_replacement_text', arguments); }
+// external re_replacement_text: string -> int array -> string -> string
+function re_replacement_text(_,_,s)  { str_ll('re_replacement_text', arguments);  return s; }
 //Provides: re_search_backward
 //Requires: str_ll
-function re_search_backward()        { str_ll('re_search_backward', arguments); }
+// external re_search_backward: regexp -> string -> int -> int array
+function re_search_backward()        { str_ll('re_search_backward', arguments);   return [0]; }

--- a/coq-libjs/str.js
+++ b/coq-libjs/str.js
@@ -33,7 +33,7 @@ function re_partial_match()          { str_ll('re_partial_match', arguments);   
 //Provides: re_replacement_text
 //Requires: str_ll
 // external re_replacement_text: string -> int array -> string -> string
-function re_replacement_text(_,_,s)  { str_ll('re_replacement_text', arguments);  return s; }
+function re_replacement_text(r,a,s)  { str_ll('re_replacement_text', arguments);  return s; }
 //Provides: re_search_backward
 //Requires: str_ll
 // external re_search_backward: regexp -> string -> int -> int array

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,14 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
       "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
     },
+    "find": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find/-/find-0.3.0.tgz",
+      "integrity": "sha512-iSd+O4OEYV/I36Zl8MdYJO0xD82wH528SaCieTVHhclgiYNe9y+yPKSwK+A7/WsmHL1EZ+pYUJBXWTL5qofksw==",
+      "requires": {
+        "traverse-chain": "~0.1.0"
+      }
+    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -87,6 +95,20 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
       "integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA=="
     },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -109,6 +131,19 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "traverse-chain": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE="
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "dependencies": {
     "bootstrap": "^3.4.1",
     "codemirror": "^5.42.2",
+    "find": "^0.3.0",
     "jquery": "^3.3.1",
     "jszip": "^3.1.5",
     "localforage": "^1.7.3",
-    "neatjson": "^0.8.3"
+    "neatjson": "^0.8.3",
+    "path": "^0.12.7"
   },
   "devDependencies": {},
   "repository": {

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -351,7 +351,7 @@ class CoqManager {
     }
 
     updateLocalSymbols() {
-        this.coq.inspectPromise(["CurrentFile"])
+        this.coq.inspectPromise(0, ["CurrentFile"])
         .then(bunch => {
             CodeMirror.CompanyCoq.loadSymbols(
                 { lemmas: bunch.map(CoqIdentifier.ofKerName) },


### PR DESCRIPTION
I have completed the implementation of the Inspect worker command that generates a list of available symbols. This would allow for better completions.

Perhaps you've done something similar in lsp. Anyway, this looks useful to have in jsCoq for now.