### PR TITLE
Node.js command-line interface (PoC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean upload all libs coq-tools
+.PHONY: all clean upload all libs libs-pkg libs-symb coq-tools
 .PHONY: bytecode_bin javascript_bin
 .PHONY: dist dist-upload dist-release dist-hott force
 .PHONY: coq coq-get coq-build
@@ -72,6 +72,12 @@ libs: coq-all-libs
 libs-pkg:
 	node coq-tools/mkpkg.js coq-pkgs/*.json
 	node coq-tools/mkdeps.js coq-pkgs/init.json coq-pkgs/coq-*.json $(COQDIR)/.vfiles.d
+
+# Build symbol database files for autocomplete
+coq-pkgs/%.symb: coq-pkgs/%.json
+	node --max-old-space-size=2048 ui-js/coq-cli.js --require-pkg $< --inspect $@
+
+libs-symb: ${patsubst %.json, %.symb, coq-pkgs/init.json ${wildcard coq-pkgs/coq-*.json}}
 
 ########################################################################
 # Dists                                                                #

--- a/coq-js/jscoq.js
+++ b/coq-js/jscoq.js
@@ -2,7 +2,7 @@
 
 class CoqWorker {
 
-    constructor(scriptPath) {
+    constructor(scriptPath, worker) {
         this.options = {
             debug: false
         };
@@ -12,10 +12,11 @@ class CoqWorker {
 
         // Create actual worker. Ideally, CoqWorker would extend
         // Worker, but this is not supported at the moment.
-        this.worker = new Worker(scriptPath || (CoqWorker.scriptDir + "jscoq_worker.js"))
+        this.worker = worker || new Worker(scriptPath || (CoqWorker.scriptDir + "jscoq_worker.js"))
         this.worker.onmessage = evt => this.coq_handler(evt);
 
-        window.addEventListener('unload', () => this.worker.terminate());
+        if (typeof window !== 'undefined')
+            window.addEventListener('unload', () => this.worker.terminate());
     }
 
     sendCommand(msg) {

--- a/coq-tools/mkpkg.js
+++ b/coq-tools/mkpkg.js
@@ -46,7 +46,7 @@ class PackageDefinition {
     listModules() {
         var modules = [];
         for (let pkg of this.manifest.pkgs) {
-            for (let file_entry of (pkg.vo_files || []).concat(pkg.cma_files || [])) {
+            for (let file_entry of (pkg.vo_files || [])) {
                 let modlabel = file_entry[0].replace(/[.](vo|cm[oa])$/, '');
                 modules.push([...pkg.pkg_id, modlabel].join('.'));
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,11 @@
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.42.2.tgz",
       "integrity": "sha512-Tkv6im39VuhduFMsDA3MlXcC/kKas3Z0PI1/8N88QvFQbtOeiiwnfFJE4juGyC8/a4sb1BSxQlzsil8XLQdxRw=="
     },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+    },
     "core-js": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
@@ -55,7 +60,7 @@
     "jquery": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha1-lYzinoHJeQ8xvneS311NlfxX+8o="
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "jszip": {
       "version": "3.1.5",
@@ -80,7 +85,7 @@
     "localforage": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
-      "integrity": "sha1-AIKzypc0Z54b1TSZW907JM8Q8gQ=",
+      "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
       "requires": {
         "lie": "3.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "bootstrap": "^3.4.1",
     "codemirror": "^5.42.2",
+    "commander": "^2.19.0",
     "find": "^0.3.0",
     "jquery": "^3.3.1",
     "jszip": "^3.1.5",

--- a/ui-js/coq-cli.js
+++ b/ui-js/coq-cli.js
@@ -1,0 +1,227 @@
+const fs = require('fs'),
+      find = require('find'),
+      path = require('path'),
+      jscoq = require('../coq-js/jscoq'),
+      jscoq_worker = require('../coq-js/jscoq_worker'),
+      coq_manager = require('./coq-manager'),
+      format_pprint = require('./format-pprint'),
+      mkpkg = require('../coq-tools/mkpkg');
+
+
+
+class HeadlessCoqWorker extends jscoq.CoqWorker {
+    constructor() {
+        super(null, jscoq_worker.jsCoq);
+        this.worker.onmessage = evt => {
+            process.nextTick(() => this.coq_handler({data: evt}));
+        };
+    }
+}
+
+/**
+ * List package directories and .cmo files for configuring the load path.
+ */
+class CoqProject {
+    constructor() {
+        this.path = [];
+        this.cmos = [];
+    }
+    add(base_dir, base_name) {
+        this.path.push([this._prefix(base_name), [base_dir, '.']]);
+        this.cmos.push(...this._cmoFiles(base_dir));
+    }
+    addRecursive(base_dir, base_name) {
+        var prefix = this._prefix(base_name);
+        for (let dir of find.dirSync(base_dir)) {
+            var pkg = prefix.concat(path.relative(base_dir, dir).split('/'));
+            this.add(dir, pkg);
+        }
+    }
+    _cmoFiles(dir) {
+        return fs.readdirSync(dir).map(fn => /[.]cmo$/.exec(fn) && path.join(dir, fn))
+            .filter(x => x);
+    }
+    _prefix(name) {
+        return (typeof name === 'string') ? name.split('.') : name;
+    }
+}
+
+/**
+ * A manager that handles Coq events without a UI.
+ */
+class HeadlessCoqManager {
+
+    constructor() {
+        this.coq = new HeadlessCoqWorker();
+        this.coq.observers.push(this);
+        this.provider = new QueueCoqProvider();
+        this.pprint = new format_pprint.FormatPrettyPrint();
+
+        this.options = {
+            prelude: false,
+            implicit_libs: true,
+            pkg_path: "./coq-pkgs/",  // this is awkward: package path is relative to cwd
+            inspect: false
+        };
+
+        this.doc = [];
+
+        // Configure load path
+        this.project = new CoqProject();
+
+        this.project.addRecursive(`${this.options.pkg_path}/Coq`, 'Coq');
+
+        for (let fn of this.project.cmos) {
+            this.coq.register(fn);
+        }
+    }
+
+    start() {
+        let set_opts = {implicit_libs: this.options.implicit_libs, stm_debug: false},
+            init_libs = this.options.prelude ? [["Coq", "Init", "Prelude"]] : [],
+            load_path = this.project.path;
+
+        this.coq.init(set_opts, init_libs, load_path);
+    }
+
+    goNext() {
+        var last_stm = this.doc[this.doc.length - 1],
+            stm = this.provider.getNext(last_stm);
+
+        if (stm) {
+            var last_sid = (last_stm && last_stm.coq_sid) || 1;
+            stm.coq_sid = last_sid + 1;
+            this.doc.push(stm);
+            this.coq.add(last_sid, stm.coq_sid, stm.text);
+            return true;
+        }
+        else return false;
+    }
+
+    finished() {
+        console.log("Finished.");
+        if (this.options.inspect) {
+            this.coq.inspectPromise(["All"]).then(results => {
+                var json = results.map(kn => coq_manager.CoqIdentifier.ofKerName(kn)),
+                    out_fn = this.options.inspect_filename || 'symb.json';
+                fs.writeFileSync(out_fn, JSON.stringify(json));
+            });
+        }
+    }
+
+    coqReady() {
+        console.log("Coq worker ready.")
+        this.goNext();
+    }
+
+    coqLog([lvl], msg) { 
+        console.log(`[${lvl}] ${this.pprint.pp2Text(msg)}`);
+    }
+
+    coqPending(sid) {
+        var idx = this.doc.findIndex(stm => stm.coq_sid === sid);
+        if (idx >= 0) {
+            var stm = this.doc[idx],
+                prev_stm = this.doc[idx - 1];
+            this.coq.resolve((prev_stm && prev_stm.coq_sid) || 1, sid, stm.text);
+        }
+    }
+
+    coqAdded(sid) {
+        var last_stm = this.doc[this.doc.length - 1];
+        if (last_stm && last_stm.coq_sid === sid && !last_stm.added) {
+            last_stm.added = true;
+            this.coq.exec(sid);
+        }
+    }
+
+    feedProcessed(sid) {
+        var last_stm = this.doc[this.doc.length - 1];
+        if (last_stm && last_stm.coq_sid === sid && !last_stm.executed) {
+            last_stm.executed = true;
+            if (!this.goNext(sid)) this.finished();
+        }
+    }
+
+    coqCoqExn(loc, _, msg) {
+        console.error(`[Exception] ${this.pprint.pp2Text(msg)}`);
+    }
+
+    feedFileLoaded() { }
+    feedFileDependency() { }
+
+    feedProcessingIn() { }
+
+    feedMessage(sid, [lvl], loc, msg) { 
+        console.log('-'.repeat(60));
+        console.log(`[${lvl}] ${this.pprint.pp2Text(msg).replace('\n', '\n         ')}`); 
+        console.log('-'.repeat(60));
+    }
+
+}
+
+/**
+ * A provider stub that just holds a list of sentences to execute.
+ */
+class QueueCoqProvider {
+
+    constructor() {
+        this.queue = [];
+    }
+
+    enqueue(...sentences) {
+        for (let s of sentences) {
+            if (typeof s === 'string') s = {text: s};
+            this.queue.push(s);
+        }
+    }
+
+    getNext(prev) {
+        if (!prev) return this.queue[0];
+
+        for (let i = 0; i < this.queue.length; i++) {
+            if (this.queue[i] === prev) return this.queue[i+1];
+        }
+
+        return undefined;
+    }
+
+}
+
+
+
+if (module && module.id == '.') {
+    var requires, require_pkgs = [],
+        opts = require('commander')
+        .option('--noinit', 'start without loading the Init library')
+        .option('--require <path>', 'load Coq library path and import it (Require Import path.)')
+        .option('--require-pkg <json>', 'load a package and Require all modules included in it')
+        .option('--inspect [filename]', 'Inspect global symbols and serialize to file')
+        .option('-e [command]', 'Run a vernacular command')
+        .on('option:require',     path => { requires.push(path); })
+        .on('option:require-pkg', json => { require_pkgs.push(json); })
+        .parse(process.argv);
+
+    var coq = new HeadlessCoqManager();
+
+    for (let json_fn of load_requires) {
+        var bundle = mkpkg.PackageDefinition.fromFile(json_fn);
+
+        for (let modul of bundle.listModules()) {
+            coq.provider.enqueue(`Require ${modul}.`);
+        }
+    }
+
+    if (opts.prelude) coq.options.prelude = true;
+
+    if (opts.E) coq.provider.enqueue(...opts.E.split(/(?<=\.)\s+/));
+
+    if (opts.inspect) {
+        coq.options.inspect = true;
+        if (typeof opts.inspect === 'string')
+            coq.options.inspect_filename = opts.inspect;
+    }
+
+    coq.start();
+}
+

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -1123,6 +1123,9 @@ class CoqIdentifier {
     }
 }
 
+if (typeof module !== 'undefined')
+    module.exports = {CoqManager, CoqIdentifier}
+
 // Local Variables:
 // js-indent-level: 4
 // End:


### PR DESCRIPTION
This is more of a nice-to-have and constitutes ongoing work. Since jsCoq can run on Node.js, I made a small CLI utility that allows to load packages and run vernacular commands from the shell.

The motivation for this is twofold:
 * Generate symbol files for search and autocompletion functionality. (Arguably this could be done better with SerAPI.)
 * Automated unit-testing that can be made part of CI.