### PR TITLE
Separate addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,19 @@ install:
 - opam config var root
 - ./toolchain-setup.sh
 - opam list
-- make coq-get
-- make coq-build
-
-script:
-- echo 'Building JsCoq...' && echo -en 'travis_fold:start:jscoq.build\\r'
-- ./build.sh
 - git submodule update --remote
 - npm install
+
+script:
+- echo -en 'travis_fold:start:coq.build\\r'
+- make coq-get
+- make coq-build
+- echo -en 'travis_fold:end:coq.build\\r'
+- echo 'Building JsCoq...' && echo -en 'travis_fold:start:jscoq.build\\r'
+- ./build.sh
 - echo -en 'travis_fold:end:jscoq.build\\r'
+- echo -en 'travis_fold:start:addons.build\\r'
+- make addons-get
+- make addons-build
+- ./build.sh  # rebuild with addons
+- echo -en 'travis_fold:end:addons.build\\r'

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ addon-%-get:
 
 addon-%-build:
 	make -f coq-addons/$*.addon build
+	make -f coq-addons/$*.addon jscoq-install
 
 addons-get: ${foreach v,$(ADDONS),addon-$(v)-get}
 addons-build: ${foreach v,$(ADDONS),addon-$(v)-build}

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,21 @@ include config.mk
 all:
 	@echo "Welcome to jsCoq makefile. Targets are:"
 	@echo ""
-	@echo "  - bytecode_bin:   build jscoq's bytecode"
-	@echo "  - javascript_bin: build jscoq's javascript"
-	@echo "  - coq-get:        download Coq and libraries"
-	@echo "  - coq-build:      build Coq and libraries"
-	@echo "  - coq:            download and build Coq and libraries"
-	@echo "  - coq-tools:      to be removed by the Dune-based build"
+	@echo "  - bytecode        build jsCoq's bytecode"
+	@echo "  - js              build jsCoq's javascript"
+	@echo "  - coq-get         download Coq ($(COQ_VERSION))"
+	@echo "  - coq-build       build Coq and its standard library"
+	@echo "  - coq             download and build Coq and standard library"
+	@echo "  - coq-tools       [to be removed by the Dune-based build]"
+	@echo "  - addons          download and build extra libraries"
+	@echo "                    ($(ADDONS))"
+	@echo "  - libs            create package bundles in coq-pkgs"
+	@echo
 
-bytecode_bin:
+bytecode:
 	$(MAKE) -C coq-js bytecode_bin
 
-javascript_bin:
+js:
 	$(MAKE) -C coq-js javascript_bin
 
 coq-tools:
@@ -35,7 +39,7 @@ coq-tools:
 %.cmo.js: %.cmo
 	js_of_ocaml $(JSOO_OPTS) --wrap-with-fun= -o $<.js $<
 
-plugin-comp: $(addsuffix .js,$(shell find coq-pkgs \( -name *.cma -or -name *.cmo \)))
+plugin-comp: $(addsuffix .js,$(shell find coq-pkgs \( -name *.cma -or -name *.cmo \) 2>/dev/null))
 
 ########################################################################
 # Library building                                                     #

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,8 @@ Makefile.libs: coq-tools/mklibfs
 coq-libs: Makefile.libs coq-pkgs
 	COQDIR=$(COQDIR) make -f Makefile.libs libs-auto
 
-# Build extra libraries
-coq-addons: coq-pkgs
-	COQDIR=$(COQDIR) make -f Makefile.addons $(ADDONS)
-
-coq-all-libs: coq-libs coq-addons
-
 # All the libraries + json generation
-libs: coq-all-libs
+libs: coq-libs
 	./coq-tools/mklibjson # $(ADDONS)
 
 # Bundle libs and inject dependencies

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ set -e
 opam switch $OCAML_VER+32bit
 eval `opam config env`
 
-make -j $NJOBS bytecode_bin
+make -j $NJOBS bytecode
 
 # In previous versions of jsoo we needed to use a 64 jsoo due to high
 # memory demands. This is fixed in jsoo 2.8.1
@@ -16,7 +16,7 @@ make -j $NJOBS bytecode_bin
 # opam switch $OCAML_VER
 # eval `opam config env`
 
-make -j $NJOBS javascript_bin
+make -j $NJOBS js
 
 # coq-tools must be built in 32 bits too
 # opam switch $OCAML_VER+32bit

--- a/config.mk
+++ b/config.mk
@@ -17,6 +17,10 @@ current_dir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 ADDONS_PATH := $(current_dir)/coq-external
 COQDIR := $(ADDONS_PATH)/coq-$(COQ_VERSION)+32bit/
 
+ifeq "${JSCOQ_DEBUG}" "yes"
+JSOO_OPTS+= --pretty --noinline --disable shortvar --debug-info
+endif
+
 # Addons to build
 # Working on coq-8.9:
 ADDONS = mathcomp iris ltac2 elpi equations dsp

--- a/coq-addons/mathcomp.addon
+++ b/coq-addons/mathcomp.addon
@@ -24,6 +24,7 @@ build:
 	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/algebra; make; make install
 	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/solvable; make; make install
 	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/field; make; make install
+	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/character; make; make install
 
 jscoq-install:
 	mkdir -p $(MATHCOMP_DEST)
@@ -32,3 +33,4 @@ jscoq-install:
 	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/algebra $(MATHCOMP_DEST)
 	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/solvable $(MATHCOMP_DEST)
 	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/field $(MATHCOMP_DEST)
+	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/character $(MATHCOMP_DEST)

--- a/coq-js/Makefile
+++ b/coq-js/Makefile
@@ -101,11 +101,7 @@ JSFILES=$(addprefix $(JSDIR),mutex.js unix.js str.js coq_vm.js)
 # the --toplevel was previously used, but --dynlink option seems to
 # work equally fine, which one should we use? What about --nocmis,
 # does it have any effect without --toplevel?
-JSOO_OPTS = --dynlink # --nocmis
-
-ifeq "${JSCOQ_DEBUG}" "yes"
-JSOO_OPTS+= --pretty --noinline --disable shortvar --debug-info
-endif
+JSOO_OPTS += --dynlink # --nocmis
 
 # No significant effect appreciated
 # JSOO_OPTS+=-opt 3

--- a/coq-tools/dftlibs.ml
+++ b/coq-tools/dftlibs.ml
@@ -85,7 +85,6 @@ let pkgs : (string * string list * (string list * selector) list) list=
     ; ["mathcomp"; "solvable"]
     ; ["mathcomp"; "field"]
     ; ["mathcomp"; "character"]
-    ; ["mathcomp"; "odd_order"]
     ]
   ; "coq-base", [], all_of
     [ ["Coq"; "Logic"]

--- a/coq-tools/mklibjson.ml
+++ b/coq-tools/mklibjson.ml
@@ -9,7 +9,21 @@ open Yojson.Safe
 
 module Dl = Dftlibs
 
-let n_warn = ref 0
+(* Package statistics *)
+type stats = {
+  total_pkgs : int;
+  found_pkgs: int
+}
+
+let stats : (string, stats) Hashtbl.t = 
+  Hashtbl.create 15
+
+let or_zeroed = function
+  | None -> { total_pkgs = 0; found_pkgs = 0 }
+  | Some x -> x
+
+let incr_total_pkgs r = r := { !r with total_pkgs = !r.total_pkgs + 1 }
+let incr_found_pkgs r = r := { !r with found_pkgs = !r.found_pkgs + 1 }
 
 (* Make the json file for the installed libraries *)
 let is_vo s =
@@ -26,22 +40,25 @@ let select (l : string list) (sel : Dl.selector) =
   | Only s -> List.filter (fun fn -> List.mem fn s) l
   | Except s -> List.filter (fun fn -> not @@ List.mem fn s) l
 
-let build_pkg ((pid, sel) : string list * Dl.selector) : Jslib.coq_pkg =
+let build_pkg pkg ((pid, sel) : string list * Dl.selector) : Jslib.coq_pkg =
   let dummy_d   = Digest.string ""                 in
   let dir       = Dl.prefix ^ "/" ^ Dl.to_dir pid  in
+  let pkg_stats = ref (Hashtbl.find_opt stats pkg
+                       |> or_zeroed)               in
   let vo_files, cma_files =
     try
+      incr_total_pkgs pkg_stats;
       let open List                                 in
       let files = Array.to_list @@ Sys.readdir dir  in
       let files = select files sel                  in
       (* eprintf "files for %s: %n@\n" dir (List.length files); *)
+      incr_found_pkgs pkg_stats;
       filter is_vo files, filter is_cma files
     with
     | Sys_error _msg ->
-      (* eprintf "Warning: %s@\n%!" _msg; *)
-      incr n_warn;
       [], []
   in
+  Hashtbl.replace stats pkg !pkg_stats;
   {
     Jslib.pkg_id    = pid;
     vo_files  = List.map (fun s -> (s, dummy_d)) vo_files;
@@ -50,12 +67,12 @@ let build_pkg ((pid, sel) : string list * Dl.selector) : Jslib.coq_pkg =
 
 let out_pref = "coq-pkgs/"
 
-let build_pkg (pkg, deps, p_mod) =
+let build_bundle (pkg, deps, p_mod) =
   let open List                                    in
   let open Jslib                                   in
   let out    = open_out (out_pref ^ pkg ^ ".json") in
   let ofmt   = formatter_of_out_channel out        in
-  let p_mod  = map build_pkg p_mod                 in
+  let p_mod  = map (build_pkg pkg) p_mod           in
   let bundle = { desc = pkg;
                  deps = deps;
                  archive = None;
@@ -67,7 +84,23 @@ let build_pkg (pkg, deps, p_mod) =
   fprintf ofmt "%s\n" @@ pretty_to_string json;
   close_out out
 
+let seq_join sep s =
+  let l = Seq.fold_left (fun l el -> el :: l) [] s in
+  String.concat sep l
+
+let seq_is_empty seq = match seq () with
+  | Seq.Nil -> true
+  | Seq.Cons (_,_) -> false
+
 let _ =
-  List.iter build_pkg Dl.pkgs;
-  if !n_warn > 0 then
-    eprintf "Addons not found: %d@\n%!" !n_warn
+  List.iter build_bundle Dl.pkgs;
+  let pkgs = (Hashtbl.to_seq stats) in
+  let pkgs_complete = Seq.filter (fun (_pkg, stats) -> stats.total_pkgs > 0 && stats.found_pkgs = stats.total_pkgs) pkgs in
+  let pkgs_partial = Seq.filter (fun (_pkg, stats) -> stats.total_pkgs > stats.found_pkgs && stats.found_pkgs > 0) pkgs in
+  let pkgs_missing = Seq.filter (fun (_pkg, stats) -> stats.total_pkgs > 0 && stats.found_pkgs = 0) pkgs in
+  eprintf "Complete packages:\n   [%s]\n%!" (seq_join " " (Seq.map fst pkgs_complete));
+  if (not @@ seq_is_empty pkgs_missing) then
+    eprintf "Missing packages: \n   [%s]\n%!" (seq_join " " (Seq.map fst pkgs_missing));
+  if (not @@ seq_is_empty pkgs_partial) then
+    eprintf "Partially available packages:\n   [%s]\n%!"
+      (seq_join " " (Seq.map (fun (pkg, stats) -> sprintf "%s(%d/%d)" pkg stats.found_pkgs stats.total_pkgs) pkgs_partial));

--- a/coq-tools/mklibjson.ml
+++ b/coq-tools/mklibjson.ml
@@ -84,6 +84,9 @@ let build_bundle (pkg, deps, p_mod) =
   fprintf ofmt "%s\n" @@ pretty_to_string json;
   close_out out
 
+let seq_eprint s =
+  Seq.iter (fun el -> eprintf "@ %s" el) s
+
 let seq_join sep s =
   let l = Seq.fold_left (fun l el -> el :: l) [] s in
   String.concat sep l
@@ -98,9 +101,12 @@ let _ =
   let pkgs_complete = Seq.filter (fun (_pkg, stats) -> stats.total_pkgs > 0 && stats.found_pkgs = stats.total_pkgs) pkgs in
   let pkgs_partial = Seq.filter (fun (_pkg, stats) -> stats.total_pkgs > stats.found_pkgs && stats.found_pkgs > 0) pkgs in
   let pkgs_missing = Seq.filter (fun (_pkg, stats) -> stats.total_pkgs > 0 && stats.found_pkgs = 0) pkgs in
-  eprintf "Complete packages:\n   [%s]\n%!" (seq_join " " (Seq.map fst pkgs_complete));
-  if (not @@ seq_is_empty pkgs_missing) then
-    eprintf "Missing packages: \n   [%s]\n%!" (seq_join " " (Seq.map fst pkgs_missing));
-  if (not @@ seq_is_empty pkgs_partial) then
-    eprintf "Partially available packages:\n   [%s]\n%!"
-      (seq_join " " (Seq.map (fun (pkg, stats) -> sprintf "%s(%d/%d)" pkg stats.found_pkgs stats.total_pkgs) pkgs_partial));
+  eprintf "\n%!";
+  eprintf "Complete packages:\n%!   [@[<b 1>"; seq_eprint (Seq.map fst pkgs_complete); eprintf "@] ]\n%!";
+  if (not @@ seq_is_empty pkgs_missing) then begin
+    eprintf "Missing packages:\n%!   [@[<b 1>"; seq_eprint (Seq.map fst pkgs_missing); eprintf "@] ]\n%!" end;
+  if (not @@ seq_is_empty pkgs_partial) then begin
+    eprintf "Partially available packages:\n   [@[<b 1>";
+      (seq_eprint (Seq.map (fun (pkg, stats) -> sprintf "%s(%d/%d)" pkg stats.found_pkgs stats.total_pkgs) pkgs_partial));
+    eprintf "@] ]\n%!" end;
+  eprintf "\n%!"

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -28,13 +28,15 @@ make coq
 ```
 ./build.sh
 ```
- 5. Resolve JavaScript dependencies using `npm`.
+ 5. (Optional step)
+    If you want to also build the extra libraries bundled with jsCoq (mathcomp, iris, ltac2, elpi, equations, dsp):
 ```
-npm install
+make addons
+./build.sh
 ```
 
 Now serve the files at the root directory of the project via HTTP, and
 navigate your browser to `http://localhost/newide.html`, or run them locally:
 ```
- google-chrome --allow-file-access-from-files --js-flags="--harmony-tailcalls" --js-flags="--stack-size=65536" index.html
+ google-chrome --allow-file-access-from-files --js-flags="--harmony-tailcalls" --js-flags="--stack-size=65536" newide.html
 ```


### PR DESCRIPTION
This is my suggestion: separate the build of Coq from the building of the addons. It takes a long time to build all of them and some of them don't build as well as others (e.g. elpi does not build at all on macOS atm due to the ppx_deriving problem).

This PR:
 * Defines separate targets `make coq` and `make addons`.
 * Makes `libs` target independent of addons.
 * `mklibjson` reports which packages are missing. This is more useful IMO than the previous "Addons not found" warning and in fact reveals that some of the definitions in `dftlibs.ml` are perhaps spurious.