### PR TITLE
Addons cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - OPAMYES="true"
   - OPAMJOBS="2"
   - COMPILER="4.07.1+32bit"
-  - BASE_OPAM="camlp5 dune elpi"
+  - BASE_OPAM="num camlp5 dune elpi"
 
 before_install: |
   sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.1/opam-2.0.1-x86_64-linux -o /usr/bin/opam

--- a/coq-addons/mathcomp.addon
+++ b/coq-addons/mathcomp.addon
@@ -3,7 +3,6 @@
 
 include coq-addons/common.mk
 
-# From addons
 MATHCOMP_GIT=https://github.com/ejgallego/math-comp.git
 MATHCOMP_HOME=$(ADDONS_PATH)/math-comp
 MATHCOMP_DEST=coq-pkgs/mathcomp
@@ -16,18 +15,8 @@ get:
 	[ -d $(MATHCOMP_HOME) ] || git clone --depth=1 -b fast-load $(MATHCOMP_GIT) $(MATHCOMP_HOME)
 
 build:
-	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/ssreflect; make; make install
-	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/fingroup; make; make install
-	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/algebra; make; make install
-	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/solvable; make; make install
-	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/field; make; make install
-	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp/character; make; make install
+	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp; $(MAKE) -j $(NJOBS); $(MAKE) install
 
 jscoq-install:
 	mkdir -p $(MATHCOMP_DEST)
-	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/ssreflect $(MATHCOMP_DEST)
-	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/fingroup $(MATHCOMP_DEST)
-	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/algebra $(MATHCOMP_DEST)
-	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/solvable $(MATHCOMP_DEST)
-	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/field $(MATHCOMP_DEST)
-	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/character $(MATHCOMP_DEST)
+	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/ $(MATHCOMP_DEST)

--- a/coq-addons/odd-order.addon
+++ b/coq-addons/odd-order.addon
@@ -3,7 +3,7 @@
 
 # From addons
 SYNC=rsync -avq
-SYNCVO=echo "Updating $<" && rsync -avq --filter='+ */' --filter='+ **.vo' --filter='- *' --prune-empty-dirs
+SYNCVO=rsync -avq --filter='+ */' --filter='+ **.vo' --filter='- *' --prune-empty-dirs
 
 MATHCOMP_FULL_GIT=https://github.com/math-comp/math-comp.git
 MATHCOMP_FULL_HOME=$(ADDONS_PATH)/math-comp-full

--- a/coq-external/dsp/Makefile
+++ b/coq-external/dsp/Makefile
@@ -1,5 +1,5 @@
 all:
-	coqc -R . Dsp dspsupport.v
+	coqc -R . Dsp -w -notation-overridden dspsupport.v
 
 clean:
 	rm -f dspsupport.{aux,vio,vo,glob}


### PR DESCRIPTION
Tell me if this makes sense. In particular, for mathcomp, I do not see `odd_order` there, so I think we can just build with the root makefile. 

 * Does it mean we can get rid of `odd_order.addon`?
 * Does it mean that we can just build the official branch, or does your fork still load faster?