### PR TITLE
Mklibfs overhaul

### DIFF
--- a/coq-jslib/dune
+++ b/coq-jslib/dune
@@ -1,20 +1,20 @@
 (library
- (name jslib)
- (preprocess (staged_pps ppx_import ppx_deriving_yojson))
- (modules jslib)
- (libraries yojson ppx_deriving_yojson.runtime))
+ (name         jslib)
+ (preprocess   (staged_pps ppx_import ppx_deriving_yojson))
+ (modules      jslib)
+ (libraries    yojson ppx_deriving_yojson.runtime))
 
 (library
- (name dftlibs)
- (modules dftlibs))
+ (name         dftlibs)
+ (modules      dftlibs))
 
 (executable
- (public_name mklibfs)
- (modules mklibfs)
- (libraries dftlibs))
+ (public_name  mklibfs)
+ (modules      mklibfs)
+ (libraries    dftlibs unix))
 
 (executable
- (public_name mklibjson)
- (modules mklibjson)
- (libraries yojson jslib dftlibs))
+ (public_name  mklibjson)
+ (modules      mklibjson)
+ (libraries    yojson jslib dftlibs))
 

--- a/coq-jslib/mklibfs.ml
+++ b/coq-jslib/mklibfs.ml
@@ -31,6 +31,8 @@ module Fileutils = struct
       match els with | [] -> el | x :: xs -> mkdir_p ((el ^ "/" ^ x) :: xs) perm
 end
 
+let (/) = Filename.concat
+let cd cur ch = if Filename.is_relative ch then cur / ch else ch
 
 (* Determines which files are copied over *)
 let include_pat fn =
@@ -45,7 +47,7 @@ let copy_subdir coqdir basepath dirpath =
 
   let copy_single_file fn =
     try
-      Fileutils.file_copy (indir ^ "/" ^ fn) (outdir ^ "/" ^ fn)
+      Fileutils.file_copy (indir / fn) (outdir / fn)
     with Sys_error e ->
       eprintf " * @[failed to copy:@ %s/%s@]\n%!" desc fn
   in
@@ -64,5 +66,5 @@ let make_libfs coqdir =
 
 let _ =
   let coqdir = ref @@ "." in
-  Arg.parse [] (fun s -> coqdir := !coqdir ^ "/" ^ s) "" ;
+  Arg.parse [] (fun s -> coqdir := cd !coqdir s) "" ;
   make_libfs !coqdir

--- a/coq-jslib/mklibfs.ml
+++ b/coq-jslib/mklibfs.ml
@@ -7,47 +7,62 @@
 open Format
 module Dl = Dftlibs
 
-let pp_str ppf s = fprintf ppf "%s" s
 
-let rec pp_list pp fmt l = match l with
-    []         -> fprintf fmt ""
-  | csx :: []  -> fprintf fmt "%a" pp csx
-  | csx :: csl -> fprintf fmt "%a %a" pp csx (pp_list pp) csl
+(* use `fileutils`? *)
+module Fileutils = struct
+  open Unix
 
-let output_librule fmt bpath path =
-  let name    = Dl.to_name path                                in
-  (* Strip "Coq" suffix *)
-  let dir     = List.tl path                                   in
-  let coqdir  = "$(COQBUILDDIR)"                               in
-  let coqdir  = Dl.to_dir (coqdir :: bpath :: dir)             in
-  let outdir  = Dl.to_dir (Dl.prefix :: (List.hd path) :: dir) in
-  let vo_pat  = Dl.to_dir [coqdir; "*.vo"]                     in
-  let cma_pat = Dl.to_dir [coqdir; "*_plugin.cma"]             in
-  (* Rule for the dir *)
-  fprintf fmt "%s:\n\t@mkdir -p %s\n" outdir outdir;
-  (* Pattern expansion *)
-  fprintf fmt "%s_VO:=$(wildcard %s)\n"  name vo_pat;
-  fprintf fmt "%s_CMA:=$(wildcard %s)\n" name cma_pat;
-  (* Copy rule *)
-  fprintf fmt "%s: %s $(%s_VO) $(%s_CMA)\n\t@for i in $(%s_VO);  do cp -a $$i %s/`basename $$i`; done\n\t@for i in $(%s_CMA); do cp -a $$i %s/`basename $$i`; done\n\n"
-    name outdir name name name outdir name outdir
-(*
-  COQ_SETOIDS=$(COQTDIR)/Setoids/*.vo
-  COQ_SETOIDS_DEST=filesys/coq_setoids
-  coq_setoids: $(COQ_SETOIDS)
-  $(shell for i in $(COQ_SETOIDS); do base64 $$i > $(COQ_SETOIDS_DEST)/`basename $$i`; done)
-*)
+  let buffer_size = 8192
+  let buffer = Bytes.create buffer_size
 
-let output_global_rules fmt =
-  (* XXX: make dirs *)
-  fprintf fmt "libs-auto: %a\n" (pp_list pp_str) @@
-    List.map Dl.to_name (Dl.coq_theory_list @ Dl.plugin_list)
+  let file_copy input_name output_name =
+    let fd_in = openfile input_name [O_RDONLY] 0 in
+    let fd_out = openfile output_name [O_WRONLY; O_CREAT; O_TRUNC] 0o666 in
+    let rec copy_loop () = match read fd_in buffer 0 buffer_size with
+      |  0 -> ()
+      | r -> ignore (write fd_out buffer 0 r); copy_loop ()
+    in
+    copy_loop ();  close fd_in;  close fd_out
 
-let gen_makefile () =
-  List.iter (output_librule std_formatter "plugins")  Dl.plugin_list;
-  List.iter (output_librule std_formatter "theories") Dl.coq_theory_list;
-  output_global_rules std_formatter
+  let rec mkdir_p dirpath perm =
+    match dirpath with
+    | [] -> "."
+    | el :: els -> if (not @@ Sys.file_exists el) then Unix.mkdir el perm;
+      match els with | [] -> el | x :: xs -> mkdir_p ((el ^ "/" ^ x) :: xs) perm
+end
+
+
+(* Determines which files are copied over *)
+let include_pat fn =
+  Filename.(check_suffix fn ".vo" || check_suffix fn "_plugin.cma")
+
+
+let copy_subdir coqdir basepath dirpath =
+  let subdirpath = basepath :: List.tl dirpath                       in
+  let desc       = Dl.to_dir subdirpath                              in
+  let indir      = Dl.to_dir (coqdir :: subdirpath)                  in
+  let outdir     = Fileutils.mkdir_p (Dl.prefix :: dirpath) 0o755    in
+
+  let copy_single_file fn =
+    try
+      Fileutils.file_copy (indir ^ "/" ^ fn) (outdir ^ "/" ^ fn)
+    with Sys_error e ->
+      eprintf " * @[failed to copy:@ %s/%s@]\n%!" desc fn
+  in
+
+  try
+    Sys.readdir indir |> Array.to_seq 
+      |> Seq.filter include_pat |> Seq.iter copy_single_file
+  with Sys_error e ->
+    eprintf " * @[missing subdirectory:@ %s@]\n%!" 
+            (Dl.to_dir (basepath :: (List.tl dirpath)))
+
+let make_libfs coqdir =
+  List.iter (copy_subdir coqdir "plugins")  Dl.plugin_list;
+  List.iter (copy_subdir coqdir "theories") Dl.coq_theory_list
+
 
 let _ =
-  gen_makefile ()
-
+  let coqdir = ref @@ "." in
+  Arg.parse [] (fun s -> coqdir := !coqdir ^ "/" ^ s) "" ;
+  make_libfs !coqdir

--- a/dune
+++ b/dune
@@ -3,10 +3,6 @@
  (release (flags :standard -rectypes)))
 
 (rule
- (targets Makefile.libs)
- (action (with-stdout-to %{targets} (run mklibfs))))
-
-(rule
  (targets coq-pkgs)
  (deps
    (package coq)
@@ -15,8 +11,7 @@
  )
  (action
   (progn
-   (run mkdir -p coq-pkgs)
-   (run make -f %{dep:Makefile.libs} libs-auto)
+   (run mklibfs coq-external/coq-v8.10+32bit)
    (bash "for i in %{env:ADDONS=};
           do if [ -d coq-external/$i ]; then make -sf coq-addons/$i.addon jscoq-install; fi; done")
    ; This always rebuilds due to the cleaning of the target dir :(

--- a/dune
+++ b/dune
@@ -11,7 +11,7 @@
  )
  (action
   (progn
-   (run mklibfs coq-external/coq-v8.10+32bit)
+   (run mklibfs %{env:COQBUILDDIR=})
    (bash "for i in %{env:ADDONS=};
           do if [ -d coq-external/$i ]; then make -sf coq-addons/$i.addon jscoq-install; fi; done")
    ; This always rebuilds due to the cleaning of the target dir :(


### PR DESCRIPTION
So here is my devious plan: I grew weary of `Makefile.libs`, which relies on being run by Dune, but from within a `make` environment where `COQDIR` is set. It's brittle and gave me some hard time. So instead, I made `mklibfs` actually copy the files directly over to `coq-pkgs`. If you like it, we can extend it so that also the addons can be copied the same way. We can even read their `_CoqProject` files instead of listing them in `dflibs.ml`!

This PR requires rebase, this should be easy but I am waiting for the previous one.