### PR TITLE
Proposed new, decentralized package building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ DUNE_FLAGS := ${if $(DUNE_WORKSPACE), --workspace=$(DUNE_WORKSPACE),}
 NJOBS=4
 
 export NJOBS
+export BUILD_CONTEXT
+
 export COQDIR
 export COQBUILDDIR
 export ADDONS_PATH

--- a/coq-addons/common.mk
+++ b/coq-addons/common.mk
@@ -2,3 +2,5 @@
 
 SYNC=rsync -avq
 SYNCVO=rsync -avq --filter='+ */' --filter='+ **.vo' --filter='- *' --prune-empty-dirs
+
+PKGBUILD = node _build/$(BUILD_CONTEXT)/ui-js/coq-build.js

--- a/coq-addons/mathcomp.addon
+++ b/coq-addons/mathcomp.addon
@@ -5,7 +5,7 @@ include coq-addons/common.mk
 
 MATHCOMP_GIT=https://github.com/ejgallego/math-comp.git
 MATHCOMP_HOME=$(ADDONS_PATH)/math-comp
-MATHCOMP_DEST=$(COQPKGS_ROOT)/mathcomp
+MATHCOMP_DEST=$(COQPKGS_ROOT)/math-comp
 
 .PHONY: nothing get build jscoq-install
 
@@ -18,5 +18,6 @@ build:
 	export PATH=$(COQDIR)/bin:$$PATH; cd $(MATHCOMP_HOME)/mathcomp; $(MAKE) -j $(NJOBS); $(MAKE) install
 
 jscoq-install:
-	mkdir -p $(MATHCOMP_DEST)
-	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/ $(MATHCOMP_DEST)
+	$(PKGBUILD) --project $(MATHCOMP_HOME)/mathcomp        \
+	            --create-package $(MATHCOMP_DEST).coq-pkg  \
+	            --create-manifest $(MATHCOMP_DEST).json

--- a/coq-addons/sf.addon
+++ b/coq-addons/sf.addon
@@ -11,6 +11,8 @@ PLF_URL=https://www.cis.upenn.edu/~bcpierce/sf/plf-current/plf.tgz
 PLF_HOME=$(ADDONS_PATH)/plf
 PLF_DEST=coq-pkgs/PLF
 
+SF_DEST=$(COQPKGS_ROOT)/sf
+
 .PHONY: nothing get build jscoq-install
 
 nothing:
@@ -20,12 +22,10 @@ get:
 	[ -d $(PLF_HOME) ] || wget -qO- $(PLF_URL) | tar xvz -C $(ADDONS_PATH)
 
 build:
-	export PATH=$(COQDIR)/bin:$$PATH; cd $(LF_HOME);  $(MAKE) clean; $(MAKE)
-	export PATH=$(COQDIR)/bin:$$PATH; cd $(PLF_HOME); $(MAKE) clean; $(MAKE)
+	export PATH=$(COQDIR)/bin:$$PATH; cd $(LF_HOME)  && $(MAKE)
+	export PATH=$(COQDIR)/bin:$$PATH; cd $(PLF_HOME) && $(MAKE)
 
 jscoq-install:
-	mkdir -p $(LF_DEST)
-	$(SYNCVO) $(LF_HOME)/ $(LF_DEST)
-	mkdir -p $(PLF_DEST)
-	$(SYNCVO) $(PLF_HOME)/ $(PLF_DEST)
-
+	$(PKGBUILD) --projects $(LF_HOME),$(PLF_HOME)          \
+	            --create-package $(SF_DEST).coq-pkg        \
+	            --create-manifest $(SF_DEST).json

--- a/coq-jslib/dftlibs.ml
+++ b/coq-jslib/dftlibs.ml
@@ -84,13 +84,6 @@ let pkgs : (string * string list * (string list * selector) list) list =
     ; ["Coq"; "ssr"]
     ; ["mathcomp"; "ssreflect"]
     ]
-  ; "math-comp", [], all_of
-    [ ["mathcomp"; "algebra"]
-    ; ["mathcomp"; "fingroup"]
-    ; ["mathcomp"; "solvable"]
-    ; ["mathcomp"; "field"]
-    ; ["mathcomp"; "character"]
-    ]
   ; "coq-base", [], all_of
     [ ["Coq"; "Logic"]
     ; ["Coq"; "Program"]

--- a/coq-jslib/mkpkg.js
+++ b/coq-jslib/mkpkg.js
@@ -56,7 +56,7 @@ class PackageDefinition {
 
     toZip(save_as) {
         var z = new JSZip(), fopts = this.zip_file_opts;
-        z.file("coq-pkg.json", this.toJSON(this.manifest), fopts);
+        z.file("coq-pkg.json", this.toJSON(), fopts);
         for (let fn of this.listFiles()) {
             let phys = path.join(this.base_path, fn);
             if (/[.]cm[ao]$/.exec(fn))
@@ -74,8 +74,8 @@ class PackageDefinition {
             return z;
     }
 
-    toJSON(obj) {
-        return neatjson.neatJSON(obj, this.json_format_opts);
+    toJSON() {
+        return neatjson.neatJSON(this.manifest, this.json_format_opts);
     }
 
     writeManifest(to_file) {
@@ -84,7 +84,7 @@ class PackageDefinition {
         if (!to_file)
             console.error("Cannot write package manifest back: filename not given.");
         else
-            fs.writeFileSync(to_file, this.toJSON(this.manifest));
+            fs.writeFileSync(to_file, this.toJSON());
     }
 }
 


### PR DESCRIPTION
It is somewhat not very modular to have to list all packages, including addons, in `dftlibs.ml`.

On the other hand, our efforts towards building using jsCoq brought `coq-build.js` to a condition where it can create packages on its own, leaving aside the compilation itself, given that they have been already compiled using `coqc`. (This can be done via coq_makefile or Dune or whatever.)

Right now, this depends on `_CoqProject` to infer the logical names of the modules. But configuration *is* modular, and extensible to other formats.

I experimented by migrating `math-comp` to this new method. It builds `math-comp.json` and `math-comp.coq-pkg`, so even running `libs-pkg` is not needed.