### PR TITLE
Emulation of timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
  - Workaround JSOO problem with `Lazy` (@corwin-of-amber)
  - [bugfix] Contention in autocomplete between company-coq and Tex-input (@corwin-of-amber)
  - Simple UI for compiling pure-Coq projects in the browser (@corwin-of-amber, in-progress)
+ - Timeout support (@corwin-of-amber)
 
  - [ ] Automatic parsing mode.
  - [ ] Execution gutters.

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ all-dist: dist dist-release dist-upload
 COQ_BRANCH=v8.10
 COQ_REPOS=https://github.com/coq/coq.git
 
-COQ_PATCHES = trampoline lazy-noinline $(COQ_PATCHES|$(WORD_SIZE)) $(COQ_PATCHES|$(ARCH))
+COQ_PATCHES = trampoline lazy-noinline timeout $(COQ_PATCHES|$(WORD_SIZE)) $(COQ_PATCHES|$(ARCH))
 
 COQ_PATCHES|64 = coerce-32bit
 COQ_PATCHES|Darwin/32 = byte-only

--- a/etc/patches/timeout.patch
+++ b/etc/patches/timeout.patch
@@ -1,0 +1,49 @@
+diff --git a/lib/control.ml b/lib/control.ml
+index 9054507..f687b94 100644
+--- a/lib/control.ml
++++ b/lib/control.ml
+@@ -16,7 +16,14 @@ let steps = ref 0
+ 
+ let enable_thread_delay = ref false
+ 
++let timeout_deadline : (float * (unit -> unit)) option ref = ref None
++let jscoq_timeout_yield () =
++  match !timeout_deadline with
++  | Some (time, callback) -> if Unix.gettimeofday () > time then callback ();
++  | None -> ()
++
+ let check_for_interrupt () =
++  jscoq_timeout_yield ();
+   if !interrupt then begin interrupt := false; raise Sys.Break end;
+   incr steps;
+   if !enable_thread_delay && !steps = 1000 then begin
+@@ -79,11 +86,29 @@ let windows_timeout n f x e =
+     let e = Backtrace.add_backtrace e in
+     Exninfo.iraise e
+ 
++
++let unwind ~(protect:unit -> unit) f =
++  try let y = f () in protect (); y
++  with e -> protect (); raise e
++
++let jscoq_timeout n f x e =
++  let killed = ref false in
++  timeout_deadline := Some (Unix.gettimeofday () +. float_of_int n,
++                            fun () -> killed := true; interrupt := true);
++  let protect () = jscoq_timeout_yield (); timeout_deadline := None in
++  let res = try unwind ~protect (fun () -> f x) with Sys.Break -> raise e in
++  if !killed then raise e;
++  res
++
+ type timeout = { timeout : 'a 'b. int -> ('a -> 'b) -> 'a -> exn -> 'b }
+ 
++(*
+ let timeout_fun = match Sys.os_type with
+ | "Unix" | "Cygwin" -> { timeout = unix_timeout }
+ | _ -> { timeout = windows_timeout }
++*)
++
++let timeout_fun = { timeout = jscoq_timeout }
+ 
+ let timeout_fun_ref = ref timeout_fun
+ let set_timeout f = timeout_fun_ref := f


### PR DESCRIPTION
It seems that `Control.check_for_interrupt` is now called frequently enough, which means that now #9 can be implemented by providing an alternative timing mechanism.

This PR adds `jscoq_timeout`, overriding `unix_timeout` as the default timeout func.