### PR TITLE
[libs] Don't load extraction and funind in `init`.

### DIFF
--- a/coq-jslib/dftlibs.ml
+++ b/coq-jslib/dftlibs.ml
@@ -74,8 +74,6 @@ let pkgs : (string * string list * (string list * selector) list) list =
     ; ["Coq"; "syntax"]
     ; ["Coq"; "cc"]
     ; ["Coq"; "firstorder"]
-    ; ["Coq"; "extraction"]
-    ; ["Coq"; "funind"]
     ; ["Coq"; "btauto"]
     ; ["Coq"; "Init"]
     ; ["Coq"; "Bool"]
@@ -96,6 +94,8 @@ let pkgs : (string * string list * (string list * selector) list) list =
     ; ["Coq"; "Numbers"]
     ; ["Coq"; "Numbers"; "NatInt"]
     ; ["Coq"; "Numbers"; "Natural"; "Abstract"]
+    ; ["Coq"; "extraction"]
+    ; ["Coq"; "funind"]
     ] @
     [ ["Coq"; "Arith"], Only ["PeanoNat.vo"; "Le.vo"; "Lt.vo"; "Ge.vo"; "Gt.vo";
                               "Plus.vo"; "Minus.vo"; "Compare_dec.vo"; "Wf_nat.vo"]


### PR DESCRIPTION
Since 8.8, Coq's Prelude doesn't depend on these libraries.

On a more general note, we should rework the current setup and remove
dftlibs in favor of something more principled, but OMMV.