### PR TITLE
Printing support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
  - [ ] Support for UI layouts.
  - [x] Decentralized build mode for addons.
  - [ ] Dark theme - color scheme and icon set
+ - [ ] Printer-friendly formatting in documents.
 
 Pending worker tasks:
 

--- a/ui-css/coq-base.css
+++ b/ui-css/coq-base.css
@@ -491,3 +491,19 @@ div.hint-package {
   overflow: hidden;
   font-size: 1pt;
 }
+
+/* Printing options */
+
+@media print {
+  #hide-panel { display: none; }
+  a.link-to-github { display: none; }
+
+  .flex-panel:not(.collapsed) .caption {
+    border-bottom: 1px dashed #ccc;
+  }
+
+  #panel-wrapper {
+    height: calc(100% - 2px);  /* otherwise border does not show... */
+    border-bottom: 1px solid #aaa;
+  }
+}

--- a/ui-css/coq-log.css
+++ b/ui-css/coq-log.css
@@ -32,6 +32,12 @@
 #query-panel .Debug {
   display: none;
   background-size: 16px;
+
+  /* Force log indicators to show in printed output
+   * even when "Print backgrounds" is deselected in the
+   * browser's print settings */
+  -webkit-print-color-adjust: exact !important;   /* Chrome, Safari */
+  color-adjust: exact !important;                 /* Firefox */
 }
 
 /* These will override the default rule for displayed items */

--- a/ui-js/jscoq-loader.js
+++ b/ui-js/jscoq-loader.js
@@ -32,7 +32,6 @@ var loadJsCoq;
         link.href  = css+'.css';
         link.type  = "text/css";
         link.rel   = "stylesheet";
-        link.media = "screen";
 
         document.head.appendChild(link);
     };
@@ -41,8 +40,9 @@ var loadJsCoq;
         document.currentScript.attributes.src.value.replace(/[^/]*$/, '') : undefined;
 
     // In order for jsCoq to work we need to load:
-    // - Codemirror CSS [core+theme+coq]
-    // - Codemirror JS  [core+coq+emacs]
+    // - Codemirror CSS [core + themes]
+    // - Codemirror JS  [core + emacs keymap + addons]
+    // - Codemirror custom modes and addons [coq + company-coq + tex-input]
     // - jQuery
     // - JSZip
     // - localForage


### PR DESCRIPTION
This is actually a rather small change, but I am opening a PR for it because I removed `link.media = "screen"` that seems to have been put there purposefully.

Any reason why it should not go away?