### PR TITLE
Asynchronous document model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
  - Timeout support and worker reset button (@corwin-of-amber)
  - Splash image (@corwin-of-amber)
  - [bugfix] Scrolling issue with special symbols in company-coq (@corwin-of-amber)
+ - Asynchronous document management to circumvent various race conditions (@corwin-of-amber)
 
  - [ ] Automatic parsing mode.
  - [ ] Execution gutters.

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -266,26 +266,12 @@ class CmCoqProvider {
     }
 
     cursorLess(c1, c2) {
-
         return (c1.line < c2.line ||
                 (c1.line === c2.line && c1.ch < c2.ch));
     }
 
-    cursorToStart(stm) {
-
-        var doc = this.editor.getDoc();
-        var csr = doc.getCursor();
-
-        if (this.cursorLess(csr, stm.end))
-            doc.setCursor(stm.start);
-    }
-
     cursorToEnd(stm) {
-        var doc = this.editor.getDoc();
-        var csr = doc.getCursor();
-
-        if (this.cursorLess(csr, stm.end))
-            doc.setCursor(stm.end);
+        this.editor.setCursor(stm.end);
     }
 
     /**

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -768,6 +768,11 @@ class CoqManager {
             this.coq.cancel(stm.coq_sid);
             break;
         }
+
+        this.cancelled(stm);
+    }
+
+    cancelled(stm) {
         delete this.doc.stm_id[stm.coq_sid];
         delete stm.coq_sid;
 
@@ -788,7 +793,7 @@ class CoqManager {
         }
         
         for (let follow of this.doc.sentences.slice(stm_index)) {
-            this.cancel(follow);
+            this.cancelled(follow);
         }
 
         this.doc.sentences.splice(stm_index);

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -703,6 +703,16 @@ class CoqManager {
     }
 
     /**
+     * Focus the snippet containing the stm and place the cursor at
+     * the end of the sentence.
+     */
+    focus(stm) {
+        this.currentFocus = stm.sp;
+        this.currentFocus.focus();
+        this.provider.cursorToEnd(stm);
+    }
+
+    /**
      * Document processing state machine.
      * Synchronizes the managers document (this.doc) with the Stm document
      * held by the worker.
@@ -782,16 +792,6 @@ class CoqManager {
         }
 
         this.doc.sentences.splice(stm_index);
-    }
-
-    /**
-     * Focus the snippet containing the stm and place the cursor at
-     * the end of the sentence.
-     */
-    focus(stm) {
-        this.currentFocus = stm.sp;
-        this.currentFocus.focus();
-        this.provider.cursorToEnd(stm);
     }
 
     // Error handler.


### PR DESCRIPTION
Yet another PR!

This time I wanted to rework the document held by CoqManager to facilitate asynchronous interaction with the UI and avoid different kinds of race conditions (e.g. sentence is added and then remove before the add was completed, etc.).

I think the resulting code is also somewhat cleaner, and further refactoring can be done on top of it to separate the document from CoqManager (and the DOM manipulating stuff).