### PR TITLE
Open/save file dialogs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
  - Splash image (@corwin-of-amber)
  - [bugfix] Scrolling issue with special symbols in company-coq (@corwin-of-amber)
  - A scratchpad - a page with just an empty editor (@corwin-of-amber)
+ - Open/save file dialogs that support local persistence (in the browser) and files (@corwin-of-amber)
 
  - [ ] Automatic parsing mode.
  - [ ] Execution gutters.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ the `CoqManager` constructor:
 | `prelude`       | boolean         | `true`          | Load the Coq prelude (`Coq.Init.Prelude`) at startup. (If set, make sure that `init_pkgs` includes `'init'`.) |
 | `implicit_libs` | boolean         | `false`         | Allow `Require`ing modules by short name only (e.g., `Require Arith.`).                                       |
 | `theme`         | string          | `'light'`       | IDE theme to use; includes icon set and color scheme. Supported values are `'light'` and `'dark'`.            |
+| `file_dialog`   | boolean         | `false`         | Enables UI for loading and saving files (^O/^S, or ⌘O/⌘S on Mac).                                             |
 | `editor`        | object          | `{}`            | Additional options to be passed to CodeMirror.                                                                |
 | `coq`           | object          | `{}`            | Additional Coq option values to be set at startup.                                                            |
 

--- a/examples/scratchpad.html
+++ b/examples/scratchpad.html
@@ -27,15 +27,25 @@
         base_path: '../',
         init_pkgs: ['init'],
         all_pkgs:  ['init', 'coq-base', 'coq-collections', 'coq-arith', 'coq-reals', 'math-comp'],
+        file_dialog: true,
         implicit_libs: true,
         editor: { mode: { 'company-coq': true }, keyMap: 'default' }
     };
 
     /* Global reference */
-    var coq;
+    var coq, last_filename = localStorage['scratchpad.last_filename'];
+
+    if (last_filename)
+      document.getElementById('ide-wrapper')
+              .setAttribute('data-filename', last_filename);
 
     loadJsCoq(jscoq_opts.base_path)
         .then( () => coq = new CoqManager(jscoq_ids, jscoq_opts) );
+
+    window.addEventListener('beforeunload', () => {
+      var sp = coq.provider.snippets[0];
+      localStorage['scratchpad.last_filename'] = sp.filename;
+    });
   </script>
 </body>
 </html>

--- a/ui-css/coq-base.css
+++ b/ui-css/coq-base.css
@@ -68,7 +68,7 @@ a, a:link, a:visited, a:active {
   width: 45%;
   height: 100%;
   transition: width 0.5s ease;
-  z-index: 6;
+  z-index: 20;  /* notice: CodeMirror-dialog is at index 15 */
 }
 
 #ide-wrapper.toggled #panel-wrapper {
@@ -303,6 +303,18 @@ a, a:link, a:visited, a:active {
 /* overloads */
 .CodeMirror {
   height: 100%;
+}
+
+.CodeMirror-dialog {
+  padding: .75em;
+}
+
+.CodeMirror-dialog a.dialog-link {
+  cursor: pointer;
+  text-decoration: underline;
+  font-family: sans-serif;
+  font-size: 80%;
+  padding-left: 2em;
 }
 
 /* Proper  */

--- a/ui-css/coq-dark.css
+++ b/ui-css/coq-dark.css
@@ -66,9 +66,21 @@
 /*.CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background-color: #000; }*/
 /*.CodeMirror { color: #fff; }*/
 
+.cm-s-blackboard .CodeMirror-dialog,
+.cm-s-darcula .CodeMirror-dialog {
+  background: #333;
+  border-bottom: 1px solid #999;
+  box-shadow: 0 1px 4px #666;
+}
+
+.cm-s-blackboard .CodeMirror-dialog a.dialog-link,
+.cm-s-darcula .CodeMirror-dialog a.dialog-link {
+  color: #bbf;
+}
+
 .cm-s-blackboard .CodeMirror-gutters {
-    background: #000;
-    border-right: 1px solid #272727;
+  background: #000;
+  border-right: 1px solid #272727;
 }
 
 .cm-s-blackboard .coq-eval-ok {

--- a/ui-css/coq-light.css
+++ b/ui-css/coq-light.css
@@ -84,6 +84,19 @@ body {
     background: #f1f1f1;
 }
 
+.cm-s-default .CodeMirror-dialog {
+  border-bottom: 1px solid #bbb;
+  box-shadow: 0px 1px 5px 0px #00000059;
+}
+
+.cm-s-default .CodeMirror-dialog a.dialog-link {
+  color: #22f;
+}
+
+.cm-s-default .CodeMirror-dialog a.dialog-link:active {
+  color: #228;
+}
+
 /* Vernaculars */
 .cm-builtin {
   color: #00FFFF;

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -87,7 +87,11 @@ class CmCoqProvider {
     }
 
     focus() {
-        this.editor.focus();
+        var dialog_input = this.editor.getWrapperElement()
+            .querySelector('.CodeMirror-dialog');
+        // If a dialog is open, editor.focus() will close it,
+        // leading to poor UX.
+        if (!dialog_input) this.editor.focus();
     }
 
     // If prev == null then get the first.
@@ -456,7 +460,9 @@ class CmCoqProvider {
         }
     }
 
-    saveLocal() {
+    saveLocal(filename) {
+        if (filename) this.filename = filename;
+
         if (this.filename) {
             var file_store = this.getLocalFileStore();
             file_store.setItem(this.filename, this.editor.getValue());
@@ -483,6 +489,68 @@ class CmCoqProvider {
         return CmCoqProvider.file_store;
     }
 
+    // Save/load UI
+
+    openLocalDialog() {
+        var span = this._makeFileDialog("Open file: "),
+            a = $('<a>').addClass('dialog-link').text('From disk...')
+                        .mousedown(ev => ev.preventDefault())
+                        .click(() => this.openFileDialog());
+
+        span.append(a);
+
+        this.editor.openDialog(span[0], sel => this.openLocal(sel));
+    }
+
+    openFileDialog() {
+        var input = $('<input>').attr('type', 'file');
+        input.change(() => {
+            if (input[0].files[0]) this.openFile(input[0].files[0]);
+        });
+        input.click();
+    }
+
+    saveLocalDialog() {
+        var span = this._makeFileDialog("Save file: ");
+
+        this.editor.openDialog(span[0], sel => this.saveLocal(sel), 
+                               {value: this.filename});
+    }
+
+    _makeFileDialog(text) {
+        var list_id = 'cm-provider-local-files',
+            input = $('<input>').attr('list', list_id),
+            list = $('<datalist>').attr('id', list_id);
+        
+        this.getLocalFileStore().keys().then((keys) => {
+            for (let key of keys) {
+                list.append($('<option>').val(key));
+            }
+        });
+
+        this._setupTabCompletion(input, list);
+
+        return $('<span>').text(text).append(input, list);
+    }
+
+    _setupTabCompletion(input, list) {
+        input.keydown(ev => { if (ev.key === 'Tab') {
+            this._complete(input, list);
+            ev.preventDefault(); ev.stopPropagation(); } 
+        });
+    }
+
+    _complete(input, list) {
+        var value = input.val();
+
+        if (value) {
+            var match = list.children('option').get()
+                            .find(o => o.value.includes(value));
+            if (match) {
+                input.val(match.value);
+            }
+        }
+    }
 }
 
 // Local Variables:

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -31,6 +31,9 @@ Object.defineProperty(Array.prototype, "flatten",  {enumerable: false});
 Object.defineProperty(Array.prototype, "findLast", {enumerable: false});
 Object.defineProperty(Array.prototype, "equals",   {enumerable: false});
 
+if (typeof navigator !== 'undefined')
+    navigator.isMac = /Mac/.test(navigator.platform);
+
 
 /***********************************************************************/
 /* A Provider Container aggregates several containers, the main deal   */
@@ -204,6 +207,7 @@ class CoqManager {
             all_pkgs:  ['init', 'math-comp',
                         'coq-base', 'coq-collections', 'coq-arith', 'coq-reals', 'elpi', 'equations', 'ltac2',
                         'coquelicot', 'flocq', 'lf', 'plf', 'cpdt', 'color' ],
+            file_dialog: false,
             coq:       { /* Coq option values */ },
             editor:    { /* codemirror options */ }
             // Disabled on 8.6
@@ -868,35 +872,45 @@ class CoqManager {
         if (e.keyCode === 119) // F8
             this.layout.toggle();
 
-        // All other keybindings are prefixed by alt.
-        if (!e.altKey) return true;
+        // Navigation keybindings are prefixed by alt.
+        if (e.altKey) {
+            const goCursor = () => this.goCursor(),
+                  goNext   = () => this.goNext(true),
+                  goPrev   = () => this.goPrev(true);
+            const nav_bindings = {
+                'Enter': goCursor, 'ArrowRight': goCursor,
+                'n': goNext,       'ArrowDown': goNext,
+                'p': goPrev,       'ArrowUp': goPrev
+            };
 
-        // When navigation is disabled, suppress keystrokes
-        if (!this.navEnabled && [13, 39, 78, 40, 80, 38].includes(e.keyCode)) {
-            e.preventDefault();
-            e.stopPropagation();
-            return true;
+            var op = nav_bindings[e.key];
+            if (op) {
+                e.preventDefault();
+                e.stopPropagation();
+                if (this.navEnabled) op();
+                return true;
+            }
         }
 
-        switch (e.keyCode) {
-            case 13: // ENTER
-            case 39: // Right arrow
-                this.goCursor();
+        // File keybindings are prefixed by ctrl / cmd
+        if (this.options.file_dialog &&
+            (navigator.isMac ? e.metaKey : e.ctrlKey)) {
+            const file_bindings = {
+                'o':  () => sp.openLocalDialog(),
+                '_o': () => sp.openFileDialog(),
+                's':  () => sp.saveLocal(),
+                'S':  () => sp.saveLocalDialog()
+            };
+
+            var sp = this.provider.currentFocus || this.provider.snippets[0],
+                key = (e.altKey ? '_' : '') + (e.shiftKey ? e.key.toUpperCase() : e.key),
+                op = file_bindings[key];
+            if (sp && op) {
                 e.preventDefault();
                 e.stopPropagation();
-                break;
-            case 78: // N
-            case 40: // Down arrow
-                this.goNext(true);
-                e.preventDefault();
-                e.stopPropagation();
-                break;
-            case 80: // P
-            case 38: // Up arrow
-                this.goPrev(true);
-                e.preventDefault();
-                e.stopPropagation();
-                break;
+                op();
+                return true;
+            }
         }
     }
 

--- a/ui-js/jscoq-loader.js
+++ b/ui-js/jscoq-loader.js
@@ -60,6 +60,7 @@ var loadJsCoq, JsCoq;
         loadCss(node_modules_path + 'codemirror/theme/blackboard');
         loadCss(node_modules_path + 'codemirror/theme/darcula');
         loadCss(node_modules_path + 'codemirror/addon/hint/show-hint');
+        loadCss(node_modules_path + 'codemirror/addon/dialog/dialog');
         loadCss(base_path + 'ui-css/coq-log');
         loadCss(base_path + 'ui-css/coq-base');
         loadCss(base_path + 'ui-css/coq-light');


### PR DESCRIPTION
Supports saving to local storage (usually IndexedDB) and files on disk via the systems file dialogs.

Scratchpad contents is stored as `scratchpad.v` by default, this allows the user to choose a different name and hold more than one file at a time.

The list of locally stored files is flat for now; the user can save a file as e.g. `folder/filename.v`, but files are still shown in a single list with full paths.

Key combinations are ^O, ^S (Cmd+O and Cmd+S on Mac). I guess we need to document all the key bindings somewhere. The landing page has some but perhaps it's a good idea to have another table in README.