### PR TITLE
Focus next bullet with

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
  - Port to Coq 8.10 (@ejgallego)
  - Miscellaneous improvements on the build system (@corwin-of-amber)
  - [bugfix] Error with goCursor + active error stms (@corwin-of-amber)
+ - Goal display improvements using code from serlib (@ejgallego, @corwin-of-amber)
  - Improvements on printing of feedback messages (@corwin-of-amber)
  - Preliminary support for .vo compilation (@corwin-of-amber)
  - Bind Ctrl-Space to auto-completion (@corwin-of-amber)

--- a/coq-js/jser_goals.ml
+++ b/coq-js/jser_goals.ml
@@ -1,4 +1,5 @@
 open Jser_names
+open Jser_feedback
 
 type 'a hyp =
   [%import: 'a Serapi_goals.hyp]

--- a/coq-js/serapi_goals.ml
+++ b/coq-js/serapi_goals.ml
@@ -24,6 +24,7 @@ type 'a ser_goals =
   ; stack : ('a list * 'a list) list
   ; shelf : 'a list
   ; given_up : 'a list
+  ; bullet : Pp.t option
   }
 
 (** XXX: Do we need to perform evar normalization? *)
@@ -58,6 +59,9 @@ let process_goal_gen ppx sigma g : 'a reified_goal =
   let hyps      = List.map (get_hyp ppx sigma) ctx                          in
   { name = Goal.uid g; ty = get_goal_type ppx sigma g; hyp = hyps }
 
+let if_not_empty (pp : Pp.t) =
+  if pp = Pp.mt() then None else Some pp
+
 let get_goals_gen (ppx : Environ.env -> Evd.evar_map -> Constr.t -> 'a) ~doc sid
   : 'a reified_goal ser_goals option =
   match Stm.state_of_id ~doc sid with
@@ -69,6 +73,7 @@ let get_goals_gen (ppx : Environ.env -> Evd.evar_map -> Constr.t -> 'a) ~doc sid
       ; stack = List.map (fun (g1,g2) -> ppx g1, ppx g2) stack
       ; shelf = ppx shelf
       ; given_up = ppx given_up
+      ; bullet = if_not_empty @@ Proof_bullet.suggest proof
       }
   | `Expired | `Error _ | `Valid _ -> None
 

--- a/coq-js/serapi_goals.mli
+++ b/coq-js/serapi_goals.mli
@@ -26,6 +26,7 @@ type 'a ser_goals =
   ; stack : ('a list * 'a list) list
   ; shelf : 'a list
   ; given_up : 'a list
+  ; bullet : Pp.t option
   }
 
 (** [pp_of_goals ~doc sid] returns a pp representing the current goals *)

--- a/ui-css/coq-base.css
+++ b/ui-css/coq-base.css
@@ -403,6 +403,11 @@ div.Pp_box[data-mode="horizontal"] {
   color: #777;
 }
 
+#goal-text p.num-goals + p.aside {
+  margin-top: -1em;
+  margin-bottom: 1em;
+}
+
 .coq-hypothesis > label::after {
   content: ":";
   margin: 0 .5em;

--- a/ui-js/format-pprint.js
+++ b/ui-js/format-pprint.js
@@ -278,23 +278,29 @@ class FormatPrettyPrint {
             on_shelf = goals.shelf.length,
             given_up = goals.given_up.length;
 
+        function aside(msg) {
+            var p = $('<p>').addClass('aside');
+            return (typeof msg === 'string') ? p.text(msg) : p.append(msg);
+        }
+
         if (ngoals === 0) {
             /* Empty goals; choose the appropriate message to display */
             let msg = on_stack ? "This subproof is complete, but there are some unfocused goals."
                     : (on_shelf ? "All the remaining goals are on the shelf."
                         : "No more goals."),
-                notices = given_up ? 
-                    [`(${given_up} goal${given_up > 1 ? 's were' : ' was'} admitted.)`] : [];
+                bullet_notice = goals.bullet ? [this.pp2DOM(goals.bullet)] : [],
+                given_up_notice = given_up ? 
+                    [`(${given_up} goal${given_up > 1 ? 's were' : ' was'} admitted.)`] : [],
+                notices = bullet_notice.concat(given_up_notice);
 
             return $('<div>').append(
                 $('<p>').addClass('no-goals').text(msg),
-                notices.map(txt => $('<p>').addClass('aside').text(txt))
+                notices.map(aside)
             );
         } 
         else {
             /* Construct a display of all the subgoals (first is focused) */
-            let head = $('<p>').addClass('num-goals')
-                .text(ngoals === 1 ? `1 goal` : `${ngoals} goals`),
+            let head = ngoals === 1 ? `1 goal` : `${ngoals} goals`,
                 notices = on_shelf ? [`(shelved: ${on_shelf})`] : [];
 
             let focused_goal = this.goal2DOM(goals.goals[0]);
@@ -305,8 +311,8 @@ class FormatPrettyPrint {
                     .append(this.pp2DOM(goal.ty)));
 
             return $('<div>').append(
-                head,
-                notices.map(txt => $('<p>').addClass('aside').text(txt)),
+                $('<p>').addClass('num-goals').text(head),
+                notices.map(aside),
                 focused_goal, pending_goals
             );
         }


### PR DESCRIPTION
I looked into `proof_bullet.ml` and it seems the only "public" interface is getting a `Pp.t` when a sub-goal in complete, with a human readable description of which bullet to use next.

So I added it to `serapi_goals`.