### PR TITLE
NPM Packaging!

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
  - Asynchronous document management to circumvent various race conditions (@corwin-of-amber)
  - Use serlib for serialization of Coq datatypes to JSON (@ejgallego)
  - New query `Ast` which does return a traversable Ast representation (@ejgallego)
+ - NPM package build for publishing (@corwin-of-amber)
 
  - [ ] Use sertop / serlib [partially done]
  - [ ] Automatic parsing mode.

--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,12 @@ libs-pkg: force
 
 links:
 	ln -sf _build/$(BUILD_CONTEXT)/coq-pkgs .
-	ln -sf ../_build/$(BUILD_CONTEXT)/coq-js/jscoq_worker.bc.js coq-js
-	ln -sf ../_build/$(BUILD_CONTEXT)/ui-js/coq-build.browser.js ui-js
+	ln -sf ../_build/$(BUILD_CONTEXT)/coq-js/jscoq_worker.bc.js coq-js/jscoq_worker.js
+#	ln -sf ../_build/$(BUILD_CONTEXT)/ui-js/coq-build.browser.js ui-js
 
 links-clean:
-	rm -f coq-pkgs coq-js/jscoq_worker.bc.js ui-js/coq-build.browser.js
+	rm -f coq-pkgs coq-js/jscoq_worker.js
+#	ui-js/coq-build.browser.js
 
 # Build symbol database files for autocomplete
 coq-pkgs/%.symb: coq-pkgs/%.json

--- a/Makefile
+++ b/Makefile
@@ -76,11 +76,11 @@ libs-pkg: force
 
 links:
 	ln -sf _build/$(BUILD_CONTEXT)/coq-pkgs .
-	ln -sf ../_build/$(BUILD_CONTEXT)/coq-js/jscoq_worker.js coq-js
+	ln -sf ../_build/$(BUILD_CONTEXT)/coq-js/jscoq_worker.bc.js coq-js
 	ln -sf ../_build/$(BUILD_CONTEXT)/ui-js/coq-build.browser.js ui-js
 
 links-clean:
-	rm -f coq-pkgs coq-js/jscoq_worker.js ui-js/coq-build.browser.js
+	rm -f coq-pkgs coq-js/jscoq_worker.bc.js ui-js/coq-build.browser.js
 
 # Build symbol database files for autocomplete
 coq-pkgs/%.symb: coq-pkgs/%.json
@@ -100,12 +100,26 @@ clean:
 ########################################################################
 
 BUILDDIR=_build/$(BUILD_CONTEXT)
-BUILDOBJ=$(addprefix $(BUILDDIR)/./, index.html node_modules coq-js/jscoq_worker.bc.js coq-pkgs ui-js ui-css ui-images examples ui-external/CodeMirror-TeX-input)
+BUILDOBJ=${addprefix $(BUILDDIR)/./, \
+	index.html coq-js/jscoq_worker.bc.js \
+	coq-pkgs ui-js ui-css ui-images examples \
+	node_modules ui-external/CodeMirror-TeX-input}
 DISTDIR=_build/dist
+
+PACKAGE_VERSION = ${shell node -e 'console.log(require("./package.json").version)'}
 
 dist: jscoq
 	mkdir -p $(DISTDIR)
 	rsync -avpR --delete $(BUILDOBJ) $(DISTDIR)
+
+NPMOBJ = ${filter-out %/node_modules, $(BUILDOBJ)} package.json package-lock.json
+NPMEXCLUDE = --delete-excluded --exclude '*.vo' --exclude '*.cma'
+
+dist-npm:
+	mkdir -p $(DISTDIR)
+	rsync -avpR --delete $(NPMEXCLUDE) $(NPMOBJ) $(DISTDIR)
+	tar zcf $(DISTDIR)/jscoq-$(PACKAGE_VERSION).tar.gz   \
+	    -C $(DISTDIR) --exclude '*.tar.gz' .
 
 ########################################################################
 # Local stuff and distributions

--- a/Makefile
+++ b/Makefile
@@ -113,12 +113,14 @@ dist: jscoq
 	mkdir -p $(DISTDIR)
 	rsync -avpR --delete $(BUILDOBJ) $(DISTDIR)
 
-NPMOBJ = ${filter-out %/node_modules, $(BUILDOBJ)} package.json package-lock.json
+NPMOBJ = ${filter-out %/node_modules %/index.html, $(BUILDOBJ)}
+NPMOBJ += package.json package-lock.json
 NPMEXCLUDE = --delete-excluded --exclude '*.vo' --exclude '*.cma'
 
 dist-npm:
 	mkdir -p $(DISTDIR)
 	rsync -avpR --delete $(NPMEXCLUDE) $(NPMOBJ) $(DISTDIR)
+	cp docs/npm-landing.html $(DISTDIR)/index.html
 	tar zcf $(DISTDIR)/jscoq-$(PACKAGE_VERSION).tar.gz   \
 	    -C $(DISTDIR) --exclude '*.tar.gz' .
 

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,9 @@ dist-npm:
 	mkdir -p $(DISTDIR)
 	rsync -avpR --delete $(NPMEXCLUDE) $(NPMOBJ) $(DISTDIR)
 	cp docs/npm-landing.html $(DISTDIR)/index.html
+	sed -i.bak 's/\(is_npm:\) false/\1 true/' $(DISTDIR)/ui-js/jscoq-loader.js
 	tar zcf $(DISTDIR)/jscoq-$(PACKAGE_VERSION).tar.gz   \
-	    -C $(DISTDIR) --exclude '*.tar.gz' .
+	    -C $(DISTDIR) --exclude '*.bak' --exclude '*.tar.gz' .
 
 ########################################################################
 # Local stuff and distributions

--- a/docs/npm-landing.html
+++ b/docs/npm-landing.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8" />
+    <title>Using jsCoq with NPM (a template)</title>
+
+    <!-- important: this will not work from *within* the jsCoq package dir; -->
+    <!-- this template is meant to be copied to your project dir and edited -->
+    <script src="./ui-js/jscoq-loader.js"></script>
+  </head>
+
+<body>
+  <div id="ide-wrapper" class="toggled">
+    <div id="code-wrapper">
+      <div id="document">
+        <h1>Welcome to your own jsCoq development</h1>
+        <p>
+            Want to create a document like this one?
+            Copy <tt>node_modules/jscoq/examples/npm-template.html</tt>
+            and start editing.
+        </p>
+        <textarea id="coq-devel-1">
+(* Your document can embed Coq snippets! *)
+Inductive and_they_run := too(*!*).
+</textarea>
+      </div>
+    </div>
+  </div>
+
+  <!-- jsCoq configuration part -->
+  <script type="text/javascript">
+
+    var jscoq_ids  = ['coq-devel-1'];
+    var jscoq_opts = {
+        prelude:   true,
+        base_path: './',
+        editor:    { mode: { 'company-coq': true }, keyMap: 'default' },
+        init_pkgs: ['init'],
+        all_pkgs:  ['init', 'math-comp', 'iris', 'elpi', 'equations', 'ltac2', 'stdpp',
+                    'coq-base', 'coq-collections', 'coq-arith', 'coq-reals', 'lf', 'plf', 'cpdt']
+    };
+
+    JsCoq.start(jscoq_opts.base_path, '..', jscoq_ids, jscoq_opts);
+  </script>
+</body>

--- a/examples/npm-template.html
+++ b/examples/npm-template.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="content-type" content="text/html;charset=utf-8" />
+    <title>Using jsCoq with NPM (a template)</title>
+
+    <!-- important: this will not work from *within* the jsCoq package dir; -->
+    <!-- this template is meant to be copied to your project dir and edited -->
+    <script src="node_modules/jscoq/ui-js/jscoq-loader.js"></script>
+  </head>
+
+<body>
+  <div id="ide-wrapper" class="toggled">
+    <div id="code-wrapper">
+      <div id="document">
+        <h1>Write a header here</h1>
+        <p>
+            Write some text as well.
+        </p>
+        <textarea id="coq-devel-1">
+(* Write some Coq code in here *)
+        </textarea>
+      </div>
+    </div>
+  </div>
+
+  <!-- jsCoq configuration part -->
+  <script type="text/javascript">
+
+    var jscoq_ids  = ['coq-devel-1'];
+    var jscoq_opts = {
+        prelude:   true,
+        base_path: './node_modules/jscoq/',
+        editor:    { mode: { 'company-coq': true }, keyMap: 'default' },
+        init_pkgs: ['init'],
+        all_pkgs:  ['init', 'math-comp', 'iris', 'elpi', 'equations', 'ltac2', 'stdpp',
+                    'coq-base', 'coq-collections', 'coq-arith', 'coq-reals', 'lf', 'plf', 'cpdt']
+    };
+
+    JsCoq.start(jscoq_opts.base_path, './node_modules', jscoq_ids, jscoq_opts);
+  </script>
+</body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jscoq",
-  "version": "0.10.0-pre",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,5 +28,5 @@
   "bugs": {
     "url": "https://github.com/ejgallego/jscoq/issues"
   },
-  "homepage": "https://x80.org/rhino-coq/v8.10"
+  "homepage": "https://jscoq.github.io"
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
   "name": "jscoq",
-  "version": "0.10.0-pre",
-  "description": "Run the Coq Proof Assistant in your browser!",
-  "main": "index.html",
+  "version": "0.10.0",
+  "description": "A port of Coq to JavaScript -- run Coq in your browser",
   "dependencies": {
     "bootstrap": "^3.4.1",
     "codemirror": "^5.47.0",
     "commander": "^2.20.0",
     "find": "^0.3.0",
     "glob": "^7.1.3",
-    "jquery": "^3.3.1",
+    "jquery": "^3.4.0",
     "jszip": "^3.1.5",
     "localforage": "^1.7.3",
     "minimatch": "^3.0.4",
@@ -29,5 +28,5 @@
   "bugs": {
     "url": "https://github.com/ejgallego/jscoq/issues"
   },
-  "homepage": "https://github.com/ejgallego/jscoq#readme"
+  "homepage": "https://x80.org/rhino-coq/v8.10"
 }

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -284,7 +284,8 @@ class CoqManager {
         this.navEnabled = false;
 
         // The fun starts: Load the set of packages.
-        this.coq.infoPkg(this.packages.pkg_root_path, this.options.all_pkgs);
+        this.coq.when_created.then(() =>
+            this.coq.infoPkg(this.packages.pkg_root_path, this.options.all_pkgs));
     }
 
     // Provider setup

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -228,7 +228,7 @@ class CoqManager {
         this.setupDragDrop();
 
         // Setup the Coq worker.
-        this.coq           = new CoqWorker(this.options.base_path + 'coq-js/jscoq_worker.js');
+        this.coq           = new CoqWorker(this.options.base_path + 'coq-js/jscoq_worker.bc.js');
         this.coq.options   = this.options;
         this.coq.observers.push(this);
 

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -283,9 +283,14 @@ class CoqManager {
         this.error = [];
         this.navEnabled = false;
 
-        // The fun starts: Load the set of packages.
-        this.coq.when_created.then(() =>
-            this.coq.infoPkg(this.packages.pkg_root_path, this.options.all_pkgs));
+        // The fun starts: commence loading packages (asynchronously)
+        (async () => {
+            try {
+                await this.coq.when_created;
+                this.coq.infoPkg(this.packages.pkg_root_path, this.options.all_pkgs);
+            }
+            catch (err) { this.handleLaunchFailure(err); }
+        })();
     }
 
     // Provider setup
@@ -827,6 +832,20 @@ class CoqManager {
 
         this.truncate(err_stm);
         this.coq.cancel(sid);
+    }
+
+    /**
+     * Handles a critial error during worker load/launch.
+     * Typically, failure to fetch the jscoq_worker script.
+     * @param {Error} err load error
+     */
+    handleLaunchFailure(err) {
+        this.layout.log("Failed to start jsCoq worker.", 'Error');
+        if (typeof window !== 'undefined' && window.location.protocol === 'file:') {
+            this.layout.log($('<span>').html(
+                "(Serving from local file;\n" +
+                "has <i>--allow-file-access-from-files</i> been set?)"), 'Info');
+        }
     }
 
     clearErrors() {

--- a/ui-js/jscoq-loader.js
+++ b/ui-js/jscoq-loader.js
@@ -53,7 +53,8 @@ var loadJsCoq, JsCoq;
         base_path = base_path || JsCoq.base_path;
         if (/[^/]$/.exec(base_path)) base_path += "/";
 
-        node_modules_path = node_modules_path || base_path + "node_modules/";
+        node_modules_path = node_modules_path || 
+                            base_path + (JsCoq.is_npm ? "../" : "node_modules/");
         if (/[^/]$/.exec(node_modules_path)) node_modules_path += "/";
 
         loadCss(node_modules_path + 'codemirror/lib/codemirror');
@@ -92,6 +93,8 @@ var loadJsCoq, JsCoq;
 
     JsCoq = {
         base_path: scriptDir ? `${scriptDir}../` : "./",
+
+        is_npm: false,  /* indicates that jsCoq was installed via `npm install` */
 
         load(base_path, node_modules_path) {
             return loadJsCoq(base_path, node_modules_path);

--- a/ui-js/jscoq.js
+++ b/ui-js/jscoq.js
@@ -10,7 +10,7 @@ class CoqWorker {
         this.routes = [this.observers];
         this.sids = [, new Future()];
 
-        this._worker_script = scriptPath || (CoqWorker.scriptDir + "../coq-js/jscoq_worker.js");
+        this._worker_script = scriptPath || (CoqWorker.scriptDir + "../coq-js/jscoq_worker.bc.js");
 
         // Create actual worker. Ideally, CoqWorker would extend
         // Worker, but this is not supported at the moment.

--- a/ui-js/jscoq.js
+++ b/ui-js/jscoq.js
@@ -23,7 +23,7 @@ class CoqWorker {
 
     /**
      * Default location for worker script -- computed relative to the URL
-     * where this script is loaded from.
+     * from which this script is loaded.
      */
     static defaultScriptPath() {
         return new URL("../coq-js/jscoq_worker.bc.js", this.scriptUrl).href;
@@ -57,6 +57,7 @@ class CoqWorker {
         for (let url of urls) {
             try { return await head(url); } catch { }
         }
+        throw new Error(`resource not found; [${urls}]`);
     }
 
     sendCommand(msg) {


### PR DESCRIPTION
I figured that the easiest way would be to make a `tar.gz` of the distribution and then use `npm publish`.

You can try it! I published to the temporary name `@corwin.amber/jscoq`. So if you go to an empty directory and run
```
npm i @corwin.amber/jscoq
```

You will get a copy of 0.10.0 in `node_modules/@corwin.amber/jscoq`.

Some bits need to be tweaked w.r.t. paths in the directory structure created by `npm install`, so you currently if you try to open `index.html` it would fail 😞 I will play with it and fix it.

For now, I made the following decisions which we can debate on:
 * I am excluding the `.vo` files and putting only the `.coq-pkg` files. Putting both is superfluous, and the `.coq-pkg` ones offer faster serving time.
 * Since NPM does not support symlinks in distributed packages, I've done away with the link `jscoq_worker.js` => `jscoq_worker.bc.js`. I have given up on trying to serve from source tree – with Dune in the picture, this has become too brittle. (Perhaps we should phase out `make links` as well.)
 * I set the homepage to https://x80.org/rhino-coq/v8.10, makes more sense to me than pointing to the repo's README.