### PR TITLE
Tweaking the key bindings

### DIFF
--- a/ui-css/coq-base.css
+++ b/ui-css/coq-base.css
@@ -48,6 +48,14 @@ a, a:link, a:visited, a:active {
   font-family: monospace, times, Arial Unicode MS;
 }
 
+#ide-wrapper.coq-crosshair .CodeMirror-lines {
+  cursor: crosshair;
+}
+
+#ide-wrapper .CodeMirror-crosshair {
+  cursor: text; /* overrides CodeMirror (normally set when Alt is held) */
+}
+
 #script-panel {
   height: calc(100% - 37px);
 }

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -380,7 +380,7 @@ class CmCoqProvider {
 
     keyHandler(evt) {
         /* re-issue mouse enter when modifier key is pressed or released */
-        if (this.hover[0] && (evt.key === 'Meta' || evt.key === 'Alt'))
+        if (this.hover[0] && (evt.key === 'Ctrl'))
             this.onMouseEnter(this.hover[0].stm, evt);
     }
 

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -875,7 +875,7 @@ class CoqManager {
 
         // Poor-man's keymap
         let key = ((navigator.isMac ? e.metaKey : e.ctrlKey) ? '^' : '') + 
-                  (e.altKey ? '_' : '') + (e.shiftKey ? e.key.toUpperCase() : e.key);
+                  (e.altKey ? '_' : '') + (e.shiftKey ? '+' : '') + e.code;
 
         // Navigation keybindings
         const goCursor = () => this.goCursor(),
@@ -883,11 +883,17 @@ class CoqManager {
               goPrev   = () => this.goPrev(true),
               toggle   = () => this.layout.toggle();
         const nav_bindings = {
-            '_Enter': goCursor, '_ArrowRight': goCursor,
-            '_n': goNext,       '_ArrowDown': goNext,
-            '_p': goPrev,       '_ArrowUp': goPrev,
+            '_Enter':     goCursor, '_ArrowRight': goCursor,
+            '_ArrowDown': goNext,
+            '_ArrowUp':   goPrev,
             'F8': toggle
         };
+        if (!navigator.isMac) {
+            Object.assign(nav_bindings, {
+                '_KeyN': goNext,
+                '_KeyP': goPrev
+            }); /* Alt-N and Alt-P create accent characters on Mac */
+        }
 
         var op = nav_bindings[key];
         if (op) {
@@ -900,10 +906,10 @@ class CoqManager {
         // File keybindings
         if (this.options.file_dialog) {
             const file_bindings = {
-                '^o':  () => sp.openLocalDialog(),
-                '^_o': () => sp.openFileDialog(),
-                '^s':  () => sp.saveLocal(),
-                '^S':  () => sp.saveLocalDialog()
+                '^KeyO':   () => sp.openLocalDialog(),
+                '^_KeyO':  () => sp.openFileDialog(),
+                '^KeyS':   () => sp.saveLocal(),
+                '^+KeyS':  () => sp.saveLocalDialog()
             };
 
             var sp = this.provider.currentFocus || this.provider.snippets[0],
@@ -918,7 +924,6 @@ class CoqManager {
     }
 
     modifierKeyHandler(evt) {
-        console.log(evt);
         if (evt.key === 'Control') {
             if (evt.ctrlKey)
                 this.layout.ide.classList.add('coq-crosshair');


### PR DESCRIPTION
This is a small fix code-wise, but I've put it up as a PR because:
 * I switched the default key for goal-hover from Alt to Ctrl. This is due to Alt being used for navigation key bindings, which causes goal view to flash.
 * I noticed the landing page says that Cmd+Enter should also work for Mac. It does not, currently. It has before, I had to disable Cmd+arrows since it was interfering with Mac defaults for cursor movement, but Cmd+Enter specifically can be restored. Should it?