### PR TITLE
Building v8.10

### DIFF
--- a/coq-addons/common.mk
+++ b/coq-addons/common.mk
@@ -3,4 +3,4 @@
 SYNC=rsync -avq
 SYNCVO=rsync -avq --filter='+ */' --filter='+ **.vo' --filter='- *' --prune-empty-dirs
 
-PKGBUILD = node _build/$(BUILD_CONTEXT)/ui-js/coq-build.js
+PKGBUILD = node ui-js/coq-build.js

--- a/coq-addons/mathcomp.addon
+++ b/coq-addons/mathcomp.addon
@@ -25,6 +25,11 @@ build:
 
 jscoq-install:
 	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/ssreflect $(COQPKGS_ROOT)/mathcomp/
+	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/algebra $(COQPKGS_ROOT)/mathcomp/
+	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/character $(COQPKGS_ROOT)/mathcomp/
+	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/field $(COQPKGS_ROOT)/mathcomp/
+	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/fingroup $(COQPKGS_ROOT)/mathcomp/	
+	$(SYNCVO) $(MATHCOMP_HOME)/mathcomp/solvable $(COQPKGS_ROOT)/mathcomp/	
 	$(PKGBUILD) --project $(MATHCOMP_HOME)/mathcomp        \
 	            --create-package $(MATHCOMP_DEST).coq-pkg  \
 	            --create-manifest $(MATHCOMP_DEST).json

--- a/dune
+++ b/dune
@@ -14,7 +14,7 @@
   (progn
    (run mklibfs %{env:COQBUILDDIR=})
    (bash "for i in %{env:ADDONS=};
-          do if [ -d coq-external/$i ]; then make -sf coq-addons/$i.addon jscoq-install; fi; done")
+          do make -f coq-addons/$i.addon jscoq-install; done")
    ; This always rebuilds due to the cleaning of the target dir :(
    (bash "for i in $(find coq-pkgs \\( -name *.cmo -or -name *.cma \\)); 
           do if [ $i -nt $i.js ]; 


### PR DESCRIPTION
I followed the instructions but things did not work. I had to hack the sources and also use the following invocation:
```make
# The default addon is mathcomp, but if you don't build jscoq first you
# don't have coq_makefile, so the addon cannot be built.
# Also, the last bit of make addons fails, but it is run again at make dist
build-jscoq:
	eval `opam env` && cd jscoq && \
		make coq     && \
		make jscoq  ADDONS= && \
		make addons  ; \
		make jscoq   && \
		make dist
	mv jscoq/_build/dist/ jscoq/_build/jscoq
	cd jscoq/_build/ && tar -czf ../../jscoq.tgz jscoq
```

Notes:
- The npm related change should be improved: this way it works when called via `make dist`, but fails when called by make addons
- The `if then else` removed from `dune` may be related to the line `; (source_tree coq-external)` but I'm not sure.
- The mathcomp.addon change seems reasonable (since you built the entire MC), but then the odd-order/math-comp-full addon should be suppressed.
