### PR TITLE
[jscoq] [build] Update toolchain

### DIFF
--- a/coq-js/dune
+++ b/coq-js/dune
@@ -9,7 +9,7 @@
 (executable
  (name jscoq_worker)
  (modules jscoq_worker)
- (modes byte)
+ (modes byte js)
  (preprocess (staged_pps lwt_ppx js_of_ocaml.ppx ppx_import ppx_deriving_yojson))
  (js_of_ocaml
   (javascript_files

--- a/dune
+++ b/dune
@@ -50,8 +50,8 @@
   (deps
     coq-js/jscoq_worker.js))
 
-(alias
- (name libs-pkg)
+(rule
+ (alias libs-pkg)
  (deps coq-pkgs)
  (action
    (progn

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,5 @@
-(lang dune 1.6)
+(lang dune 2.1)
 (name jscoq)
+
+; Must fix
+(allow_approximate_merlin)

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,4 +1,4 @@
-(lang dune 1.7)
+(lang dune 2.1)
 
 (context
  (opam (switch jscoq+32bit)

--- a/dune-workspace-64
+++ b/dune-workspace-64
@@ -1,4 +1,4 @@
-(lang dune 1.7)
+(lang dune 2.1)
 
 (context
  (opam (switch jscoq+64bit)

--- a/jscoq.opam
+++ b/jscoq.opam
@@ -12,19 +12,19 @@ doc:          "https://ejgallego.github.io/jscoq/doc"
 
 depends: [
   "ocaml"               { >= "4.07.1"           }
-  "dune"                { >= "1.10.3"           }
-  "js_of_ocaml"         { >= "3.5.1"            }
-  "js_of_ocaml-ppx"     { >= "3.5.1"            }
-  "js_of_ocaml-lwt"     { >= "3.5.1"            }
+  "dune"                { >= "2.1.3"            }
+  "js_of_ocaml"         { >= "3.5.2"            }
+  "js_of_ocaml-ppx"     { >= "3.5.2"            }
+  "js_of_ocaml-lwt"     { >= "3.5.2"            }
   "yojson"              { >= "1.7.0"            }
-  "ppx_deriving_yojson" { >= "3.4"              }
-  "ppx_import"          { build & >= "1.5-3"    }
-  "lwt_ppx"             { >= "1.2.1"            }
+  "ppx_deriving_yojson" { >= "3.5.1"            }
+  "ppx_import"          { build & >= "1.6.2"    }
+  "lwt_ppx"             { >= "1.2.4"            }
   # We should just rely on OPAM's serlib but this is still early
-  "sexplib"             { >= "v0.11.0"           }
-  "ppx_sexp_conv"       { build   & >= "v0.11.0" }
+  "sexplib"             { >= "v0.12.0"           }
+  "ppx_sexp_conv"       { build   & >= "v0.12.0" }
   # We build a local, patched Coq, but however it is still a dep
-  # "coq"                 { >= "8.9.0" & < "8.10" }
+  # "coq"                 { >= "8.11.0" & < "8.12" }
   "num"
 ]
 


### PR DESCRIPTION
We do require a recent toolchain [except for the compiler which is
stuck at 4.07.1 due to ppx_import]