### PR TITLE
A policy where `implicit` only applies to Coq libs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
    problematic tho, you can however use primitive floats normally, and
    load .vo files that where compiled with `coqc` using primitive
    floats normally (@ejgallego)
+ - Enforce explicit module prefix in `Require` statements for non-Coq
+   packages, to avoid ambiguity (@corwin-of-amber)
 
  - [ ] Automatic parsing mode.
  - [ ] Execution gutters.

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ the `CoqManager` constructor:
 |-----------------|-----------------|-----------------|---------------------------------------------------------------------------------------------------------------|
 | `base_path`     | string          | `'./'`          | Path where jsCoq is installed.                                                                                |
 | `wrapper_id`    | string          | `'ide-wrapper'` | Id of `<div>` element in which the jsCoq panel is to be created.                                              |
-| `layout`        | string          | `'flex'`        | Choose between a flex-based layout (`'flex'`) and one based on fixed positioning (`'fixed'`).               |
+| `layout`        | string          | `'flex'`        | Choose between a flex-based layout (`'flex'`) and one based on fixed positioning (`'fixed'`).                 |
 | `all_pkgs`      | array of string | (see below)     | List of available packages that will be listed in the packages panel.                                         |
 | `init_pkgs`     | array of string | `['init']`      | Packages to load at startup.                                                                                  |
 | `prelude`       | boolean         | `true`          | Load the Coq prelude (`Coq.Init.Prelude`) at startup. (If set, make sure that `init_pkgs` includes `'init'`.) |
-| `implicit_libs` | boolean         | `false`         | Allow `Require`ing modules by short name only (e.g., `Require Arith.`).                                       |
+| `implicit_libs` | boolean         | `false`         | Allow `Require`ing Coq built-in modules by short name only (e.g., `Require Arith.`).                          |
 | `theme`         | string          | `'light'`       | IDE theme to use; includes icon set and color scheme. Supported values are `'light'` and `'dark'`.            |
 | `file_dialog`   | boolean         | `false`         | Enables UI for loading and saving files (^O/^S, or ⌘O/⌘S on Mac).                                             |
 | `editor`        | object          | `{}`            | Additional options to be passed to CodeMirror.                                                                |

--- a/coq-js/jslibmng.ml
+++ b/coq-js/jslibmng.ml
@@ -222,6 +222,10 @@ let rec last = function
     | [x] -> Some x
     | _ :: t -> last t
 
+let is_intrinsic = function
+    | "Coq" :: t -> true
+    | _ -> false
+
 let path_to_coqpath ?(implicit=false) ?(unix_prefix=[]) lib_path =
   let phys_path =  (* HACK to allow manual override of dir path *)
     if last unix_prefix = Some "." then unix_prefix
@@ -232,7 +236,7 @@ let path_to_coqpath ?(implicit=false) ?(unix_prefix=[]) lib_path =
         unix_path = String.concat "/" phys_path;
         coq_path = Names.(DirPath.make @@ List.rev_map Id.of_string lib_path);
         has_ml = AddTopML;
-        implicit = implicit;
+        implicit = implicit && is_intrinsic lib_path;
       };
     recursive = false;
   }

--- a/ui-js/coq-packages.js
+++ b/ui-js/coq-packages.js
@@ -49,7 +49,6 @@ class PackageManager {
 
         this.panel.insertBefore(div, place_before /* null == at end */ );
 
-        var desc = pkg_info.desc;
         var pkgs = pkg_info.pkgs;
         var no_files = 0;
 
@@ -110,15 +109,19 @@ class PackageManager {
 
     searchBundleInfo(prefix, module_name, exact=false) {
         // Look for a .vo file matching the given prefix and module name
-        var suffix = module_name.slice(0, -1),
+        var implicit = (prefix.length === 0),
+            suffix = module_name.slice(0, -1),
             basename = module_name.slice(-1)[0],
             possible_filenames = ['.vo', '.vio'].map(x => basename + x);
 
         let startsWith = (arr, prefix) => arr.slice(0, prefix.length).equals(prefix);
         let endsWith = (arr, suffix) => suffix.length == 0 || arr.slice(-suffix.length).equals(suffix);
 
+        let isIntrinsic = (arr) => arr[0] === 'Coq';
+
         let pkg_matches = exact ? pkg_id => pkg_id.equals(suffix)
-                                : pkg_id => startsWith(pkg_id, prefix) &&
+                                : pkg_id => (implicit ? isIntrinsic(pkg_id)
+                                                      : startsWith(pkg_id, prefix)) &&
                                             endsWith(pkg_id, suffix);
 
         for (let bundle_key in this.bundles) {


### PR DESCRIPTION
All other libraries will require an explicit prefix in `Require`, even with the `implicit_libs` flag.

See #150.