### PR TITLE
Several CSS+JS improvements for better integration with Web pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
    packages, to avoid ambiguity (@corwin-of-amber)
  - Init options for finer control of jsCoq's behavior: `show`, `focus`,
    `replace`, and `init_import` (@corwin-of-amber)
+ - Line numbers continue across code snippets on the same page. Useful
+   for `coqdoc`-generated pages (@corwin-of-amber)
 
  - [ ] Automatic parsing mode.
  - [ ] Execution gutters.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
    floats normally (@ejgallego)
  - Enforce explicit module prefix in `Require` statements for non-Coq
    packages, to avoid ambiguity (@corwin-of-amber)
+ - Init options for finer control of jsCoq's behavior: `show`, `focus`,
+   `replace`, and `init_import` (@corwin-of-amber)
 
  - [ ] Automatic parsing mode.
  - [ ] Execution gutters.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ the `CoqManager` constructor:
 | `show`          | boolean         | `true`          | Opens up the jsCoq panel on startup.                                                                          |
 | `focus`         | boolean         | `true`          | Sets the focus to the editor once jsCoq is ready.                                                             |
 | `replace`       | boolean         | `false`         | Replace `<div>`(s) referred to by `jscoq_ids` with jsCoq editors, moving the text content.                    |
+| `line_numbers`  | string          | `continue`      | Line numbering policy; across code snippets on page (`continue`) or separate per snippet (`restart`).         |
 | `file_dialog`   | boolean         | `false`         | Enables UI for loading and saving files (^O/^S, or ⌘O/⌘S on Mac).                                             |
 | `editor`        | object          | `{}`            | Additional options to be passed to CodeMirror.                                                                |
 | `coq`           | object          | `{}`            | Additional Coq option values to be set at startup.                                                            |

--- a/README.md
+++ b/README.md
@@ -156,9 +156,13 @@ the `CoqManager` constructor:
 | `layout`        | string          | `'flex'`        | Choose between a flex-based layout (`'flex'`) and one based on fixed positioning (`'fixed'`).                 |
 | `all_pkgs`      | array of string | (see below)     | List of available packages that will be listed in the packages panel.                                         |
 | `init_pkgs`     | array of string | `['init']`      | Packages to load at startup.                                                                                  |
+| `init_import`   | array of string | `[]`            | Modules to `Require Import` on startup.                                                                       |
 | `prelude`       | boolean         | `true`          | Load the Coq prelude (`Coq.Init.Prelude`) at startup. (If set, make sure that `init_pkgs` includes `'init'`.) |
 | `implicit_libs` | boolean         | `false`         | Allow `Require`ing Coq built-in modules by short name only (e.g., `Require Arith.`).                          |
 | `theme`         | string          | `'light'`       | IDE theme to use; includes icon set and color scheme. Supported values are `'light'` and `'dark'`.            |
+| `show`          | boolean         | `true`          | Opens up the jsCoq panel on startup.                                                                          |
+| `focus`         | boolean         | `true`          | Sets the focus to the editor once jsCoq is ready.                                                             |
+| `replace`       | boolean         | `false`         | Replace `<div>`(s) referred to by `jscoq_ids` with jsCoq editors, moving the text content.                    |
 | `file_dialog`   | boolean         | `false`         | Enables UI for loading and saving files (^O/^S, or ⌘O/⌘S on Mac).                                             |
 | `editor`        | object          | `{}`            | Additional options to be passed to CodeMirror.                                                                |
 | `coq`           | object          | `{}`            | Additional Coq option values to be set at startup.                                                            |

--- a/examples/Coq86.html
+++ b/examples/Coq86.html
@@ -8,7 +8,7 @@
     <title>Use Coq in Your Browser: The Js Coq Theorem Prover Online IDE!</title>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled">
   <div id="code-wrapper">
   <div id="document">

--- a/examples/Stlc.html
+++ b/examples/Stlc.html
@@ -8,7 +8,7 @@
     <title>Use Coq in Your Browser: The Js Coq Theorem Prover Online IDE!</title>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled">
   <div id="code-wrapper">
   <div id="document">

--- a/examples/dft.html
+++ b/examples/dft.html
@@ -8,7 +8,7 @@
 
     <title>Some Exercises on the Mathematics of the DFT</title>
   </head>
-  <body>
+  <body class="jscoq-main">
     <div id="ide-wrapper" class="toggled container-fluid">
     <div id="code-wrapper">
     <div id="document">

--- a/examples/equations_intro.html
+++ b/examples/equations_intro.html
@@ -8,7 +8,7 @@
     <title>Use Coq in Your Browser: The Js Coq Theorem Prover Online IDE!</title>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled">
   <div id="code-wrapper">
   <div id="document">

--- a/examples/gentle-intro.html
+++ b/examples/gentle-intro.html
@@ -11,15 +11,32 @@
     <meta name="description" content="An Online IDE for the Coq Theorem Prover" />
 
     <title>Use Coq in Your Browser: The Js Coq Theorem Prover Online IDE!</title>
+
+    <style>
+    kbd {
+      padding: 2px 4px;
+      font-size: 85%; 
+      background: #0003; color: #333; 
+      border-radius: 3px; line-height: 2em; margin: 1px;
+      box-shadow: inset -1px -1px 0 rgba(0,0,0,.25);
+    }
+    slash::after {
+      content: "/"; 
+      font-size: 120%; font-family: times;
+      position: relative;
+      top: 2px;
+    }
+    </style>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled">
   <div id="code-wrapper">
   <div id="document">
     <p>
-    Alt+↑/↓ – move through proof; Alt+→ or Alt+⏎ – go to cursor. <br/>
-    Alt+hover executed sentences to watch intermediate steps. <br/>
+    <kbd>Alt</kbd>+<kbd>↓</kbd><slash></slash><kbd>↑</kbd> – move through proof; 
+    <kbd>Alt</kbd>+<kbd>→</kbd> or <kbd>Alt</kbd>+<kbd>⏎</kbd> – go to cursor. <br/>
+    <kbd>Ctrl</kbd>+hover executed sentences to watch intermediate proof steps. <br/>
     Hover identifiers in goals to view their types. Alt+hover to view definitions.<br/>
     <i style="color: rgb(51, 51, 150)">Company-coq</i> addon is enabled: it will auto-complete names of tactics and lemmas 
     from the standard library, and also show types of lemmas in the right pane.

--- a/examples/hott.html
+++ b/examples/hott.html
@@ -8,7 +8,7 @@
     <title>Use Coq in Your Browser: The Js Coq Theorem Prover Online IDE!</title>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled">
   <div id="code-wrapper">
   <div id="document">

--- a/examples/iris.html
+++ b/examples/iris.html
@@ -9,7 +9,7 @@
     <title>Use Coq in Your Browser: The Js Coq Theorem Prover Online IDE!</title>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled">
   <div id="code-wrapper">
   <div id="document">

--- a/examples/npm-template.html
+++ b/examples/npm-template.html
@@ -9,7 +9,7 @@
     <script src="node_modules/jscoq/ui-js/jscoq-loader.js"></script>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled">
     <div id="code-wrapper">
       <div id="document">

--- a/examples/scratchpad.html
+++ b/examples/scratchpad.html
@@ -13,7 +13,7 @@
     <title>jsCoq – The Coq Theorem Prover Online IDE</title>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled" data-filename="scratchpad.v">
     <!-- Editor and panel are created here by CoqManager -->
   </div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <title>Use Coq in Your Browser: The Js Coq Theorem Prover Online IDE!</title>
   </head>
 
-<body>
+<body class="jscoq-main">
   <div id="ide-wrapper" class="toggled">
   <div id="code-wrapper">
   <div id="document">

--- a/package-lock.json
+++ b/package-lock.json
@@ -467,9 +467,9 @@
       }
     },
     "codemirror": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.47.0.tgz",
-      "integrity": "sha512-kV49Fr+NGFHFc/Imsx6g180hSlkGhuHxTSDDmDHOuyln0MQYFLixDY4+bFkBVeCEiepYfDimAF/e++9jPJk4QA=="
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.49.2.tgz",
+      "integrity": "sha512-dwJ2HRPHm8w51WB5YTF9J7m6Z5dtkqbU9ntMZ1dqXyFB9IpjoUFDj80ahRVEoVanfIp6pfASJbOlbWdEf8FOzQ=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A port of Coq to JavaScript -- run Coq in your browser",
   "dependencies": {
     "bootstrap": "^3.4.1",
-    "codemirror": "^5.47.0",
+    "codemirror": "^5.49.2",
     "commander": "^2.20.0",
     "find": "^0.3.0",
     "glob": "^7.1.3",

--- a/ui-css/coq-base.css
+++ b/ui-css/coq-base.css
@@ -119,6 +119,9 @@ a, a:link, a:visited, a:active {
   height: 100%;
   transition: width 0.5s ease;
   z-index: 20;  /* notice: CodeMirror-dialog is at index 15 */
+
+  font-family: Helvetica, Geneva, Swiss, Arial, SunSans-Regular, sans-serif;
+  font-size: 11pt;
 }
 
 #panel-wrapper * {

--- a/ui-css/coq-base.css
+++ b/ui-css/coq-base.css
@@ -6,11 +6,11 @@
 
 /* Toggle Styles */
 
-* {
+body:not(.hands-off) * {
   box-sizing: border-box;
 }
 
-body {
+body:not(.hands-off) {
   margin: 0;
   padding: 0;
   font-family: Helvetica, Geneva, Swiss, Arial, SunSans-Regular, sans-serif;
@@ -39,7 +39,6 @@ a, a:link, a:visited, a:active {
   justify-content: space-between;
   align-items: flex-start;
 }
-
 #ide-wrapper.layout-fixed.toggled {
   padding-right: 0px;
 }
@@ -64,17 +63,37 @@ a, a:link, a:visited, a:active {
   cursor: progress !important;
 }
 
-#ide-wrapper .CodeMirror span[role=presentation] {
+/* CodeMirror */
+
+.jscoq.CodeMirror {
+  font-size: 11pt;
+  height: 100%;  /* auto-size to fit content */
+  line-height: initial;
+}
+
+.jscoq.CodeMirror span[role=presentation] {
   line-height: 12px;  /* because some characters are too tall (due to alternative font glyph rendering) */
   font-family: monospace, times, Arial Unicode MS;
 }
 
-#ide-wrapper.coq-crosshair .CodeMirror-lines {
+.coq-crosshair .jscoq.CodeMirror .CodeMirror-lines {
   cursor: crosshair;
 }
 
-#ide-wrapper .CodeMirror-crosshair {
+.jscoq.CodeMirror .CodeMirror-crosshair {
   cursor: text; /* overrides CodeMirror (normally set when Alt is held) */
+}
+
+.jscoq.CodeMirror .CodeMirror-dialog {
+  padding: .75em;
+}
+
+.jscoq.CodeMirror .CodeMirror-dialog a.dialog-link {
+  cursor: pointer;
+  text-decoration: underline;
+  font-family: sans-serif;
+  font-size: 80%;
+  padding-left: 2em;
 }
 
 /*
@@ -91,12 +110,18 @@ a, a:link, a:visited, a:active {
   font-size: 80%;
 }
 
+/* Panel and sub-panels */
+
 #panel-wrapper {
   padding: 0;
   width: 45%;
   height: 100%;
   transition: width 0.5s ease;
   z-index: 20;  /* notice: CodeMirror-dialog is at index 15 */
+}
+
+#panel-wrapper * {
+  box-sizing: border-box;
 }
 
 #ide-wrapper.layout-fixed #panel-wrapper {
@@ -246,6 +271,8 @@ a, a:link, a:visited, a:active {
   fill: #f20000
 }
 
+/* Toolbar */
+
 #toolbar {
   white-space: nowrap;
   border-bottom: 1px solid #ddd;
@@ -345,23 +372,6 @@ a, a:link, a:visited, a:active {
   background-image: url(../ui-images/reset.png);
 }
 
-/* overloads */
-.CodeMirror {
-  height: 100%;
-  line-height: initial;
-}
-
-.CodeMirror-dialog {
-  padding: .75em;
-}
-
-.CodeMirror-dialog a.dialog-link {
-  cursor: pointer;
-  text-decoration: underline;
-  font-family: sans-serif;
-  font-size: 80%;
-  padding-left: 2em;
-}
 
 /* Proper  */
 

--- a/ui-css/coq-base.css
+++ b/ui-css/coq-base.css
@@ -6,11 +6,11 @@
 
 /* Toggle Styles */
 
-body:not(.hands-off) * {
+body.jscoq-main * {
   box-sizing: border-box;
 }
 
-body:not(.hands-off) {
+body.jscoq-main {
   margin: 0;
   padding: 0;
   font-family: Helvetica, Geneva, Swiss, Arial, SunSans-Regular, sans-serif;

--- a/ui-css/coq-base.css
+++ b/ui-css/coq-base.css
@@ -39,6 +39,7 @@ a, a:link, a:visited, a:active {
   justify-content: space-between;
   align-items: flex-start;
 }
+
 #ide-wrapper.layout-fixed.toggled {
   padding-right: 0px;
 }

--- a/ui-css/coq-light.css
+++ b/ui-css/coq-light.css
@@ -2,11 +2,11 @@
 
 /* Panel/body settings */
 
-body:not(.hands-off) {
+body.jscoq-main {
   background: #e4e4e4;
 }
 
-body:not(.hands-off) #document {
+body.jscoq-main #document {
   background: #fff;
 }
 

--- a/ui-css/coq-light.css
+++ b/ui-css/coq-light.css
@@ -2,11 +2,11 @@
 
 /* Panel/body settings */
 
-body {
+body:not(.hands-off) {
   background: #e4e4e4;
 }
 
-#document {
+body:not(.hands-off) #document {
   background: #fff;
 }
 

--- a/ui-css/coq-light.css
+++ b/ui-css/coq-light.css
@@ -56,7 +56,7 @@ body:not(.hands-off) #document {
 }
 
 .coq-eval-ok.coq-highlight {
-  background: #ccd;
+  background: #ebeebd;
 }
   
 .coq-eval-pending {

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -42,9 +42,6 @@ class CmCoqProvider {
         if (options)
             copyOptions(options, cmOpts);
 
-        if (typeof element === 'string' || element instanceof String) {
-            element = document.getElementById(element);
-        }
         if (element.tagName === 'TEXTAREA') {
             this.editor = CodeMirror.fromTextArea(element, cmOpts);
         } else {

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -404,7 +404,7 @@ class CmCoqProvider {
 
     keyHandler(evt) {
         /* re-issue mouse enter when modifier key is pressed or released */
-        if (this.hover[0] && (evt.key === 'Ctrl'))
+        if (this.hover[0] && (evt.key === 'Control'))
             this.onMouseEnter(this.hover[0].stm, evt);
     }
 

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -36,7 +36,8 @@ class CmCoqProvider {
                   'Tab': 'indentMore',
                   'Shift-Tab': 'indentLess',
                   'Ctrl-Space': 'autocomplete'
-              }
+              },
+              className         : "jscoq"
             };
 
         if (options)
@@ -48,7 +49,9 @@ class CmCoqProvider {
             this.editor = this.createEditor(element, cmOpts, replace);
         }
 
-        this.editor.getWrapperElement().classList.add('jscoq');
+        var classNames = (typeof cmOpts.className == 'string') ?
+                            cmOpts.className.split(/\s+/) : cmOpts.className;
+        this.editor.getWrapperElement().classList.add(...classNames);
 
         this.filename = element.getAttribute('data-filename');
         this.autosave_interval = 20000 /*ms*/;
@@ -61,11 +64,14 @@ class CmCoqProvider {
         this.onMouseLeave = (stm, ev) => {};
         this.onTipHover = (completion, zoom) => {};
         this.onTipOut = () => {};
+        this.onResize = (lineCount) => {};
 
         this.editor.on('beforeChange', (cm, evt) => this.onCMChange(cm, evt) );
 
         this.editor.on('cursorActivity', (cm) => 
             cm.operation(() => this._adjustWidgetsInSelection()));
+
+        this.trackLineCount();
 
         // Handle mouse hover events
         var editor_element = $(this.editor.getWrapperElement());
@@ -93,6 +99,15 @@ class CmCoqProvider {
             element.replaceWith(editor.getWrapperElement());
         }
         return editor;
+    }
+
+    trackLineCount() {
+        this.lineCount = this.editor.lineCount();
+        this.editor.on('change', ev => {
+            let lineCount = this.editor.lineCount();
+            if (lineCount != this.lineCount)
+                this.onResize(this.lineCount = lineCount);
+        });
     }
 
     focus() {

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -51,6 +51,8 @@ class CmCoqProvider {
             this.editor = new CodeMirror(element, cmOpts);
         }
 
+        this.editor.getWrapperElement().classList.add('jscoq');
+
         this.filename = element.getAttribute('data-filename');
         this.autosave_interval = 20000 /*ms*/;
 

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -572,9 +572,9 @@ class CmCoqProvider {
 class Deprettify {
 
     static trim(element) {
-        if (element.firstChild.nodeType === Node.TEXT_NODE)
+        if (element.firstChild && element.firstChild.nodeType === Node.TEXT_NODE)
             element.removeChild(element.firstChild);
-        if (element.lastChild.nodeType === Node.TEXT_NODE)
+        if (element.lastChild && element.lastChild.nodeType === Node.TEXT_NODE)
             element.removeChild(element.lastChild);
         return element;
     }

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -579,11 +579,16 @@ class CmCoqProvider {
 class Deprettify {
 
     static trim(element) {
-        if (element.firstChild && element.firstChild.nodeType === Node.TEXT_NODE)
+        if (element.firstChild && Deprettify.isWS(element.firstChild))
             element.removeChild(element.firstChild);
-        if (element.lastChild && element.lastChild.nodeType === Node.TEXT_NODE)
+        if (element.lastChild && Deprettify.isWS(element.lastChild))
             element.removeChild(element.lastChild);
         return element;
+    }
+
+    static isWS(element) {
+        return element.nodeType === Node.TEXT_NODE &&
+               element.nodeValue.match(/^\s*$/);
     }
 
     static cleanup(text) {

--- a/ui-js/cm-provider.js
+++ b/ui-js/cm-provider.js
@@ -19,6 +19,8 @@ class CmCoqProvider {
 
     constructor(element, options, replace) {
 
+        this.constructor._config();
+
         var cmOpts =
             { mode : { name : "coq",
                        version: 4,
@@ -48,10 +50,6 @@ class CmCoqProvider {
         } else {
             this.editor = this.createEditor(element, cmOpts, replace);
         }
-
-        var classNames = (typeof cmOpts.className == 'string') ?
-                            cmOpts.className.split(/\s+/) : cmOpts.className;
-        this.editor.getWrapperElement().classList.add(...classNames);
 
         this.filename = element.getAttribute('data-filename');
         this.autosave_interval = 20000 /*ms*/;
@@ -408,6 +406,15 @@ class CmCoqProvider {
             this.onMouseEnter(this.hover[0].stm, evt);
     }
 
+    static _config() {
+        CodeMirror.defineOption('className', null, (cm, val) => {
+            if (val) {
+                var vals = (typeof val == 'string') ? val.split(/\s+/) : val;
+                cm.getWrapperElement().classList.add(...vals);
+            }
+        });
+        this._config = () => {};
+    }
 
     // CM specific functions.
 

--- a/ui-js/coq-layout-classic.js
+++ b/ui-js/coq-layout-classic.js
@@ -116,6 +116,7 @@ class CoqLayoutClassic {
         var flex_container = this.panel.getElementsByClassName('flex-container')[0];
         flex_container.addEventListener('click', evt => { this.panelClickHandler(evt); });
 
+        this.onToggle = evt => {};
         this.panel.querySelector('#hide-panel')
             .addEventListener('click', evt => this.toggle() );
 
@@ -135,23 +136,20 @@ class CoqLayoutClassic {
 
     show() {
         this.ide.classList.remove('toggled');
+        this.onToggle({target: this, shown: true});
     }
 
     hide() {
         this.ide.classList.add('toggled');
+        this.onToggle({target: this, shown: false});
     }
 
-    toggled() {
-        return this.ide.classList.contains('toggled');
+    isVisible() {
+        return !this.ide.classList.contains('toggled');
     }
 
     toggle() {
-        if (this.toggled()) {
-            this.show();
-        }
-        else {
-            this.hide();
-        }
+        this.isVisible() ? this.hide() : this.show();
     }
 
     splash(version_info, msg, mode='wait') {

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -66,7 +66,7 @@ class ProviderContainer {
                 element = Deprettify.trim(element);
 
             // Init.
-            var cm = new CmCoqProvider(element, this.options.editor, this.options.replace);
+            let cm = new CmCoqProvider(element, this.options.editor, this.options.replace);
             cm.idx = idx++;
             this.snippets.push(cm);
 
@@ -226,6 +226,7 @@ class CoqManager {
             all_pkgs:  ['init', 'mathcomp',
                         'coq-base', 'coq-collections', 'coq-arith', 'coq-reals', 'elpi', 'equations',
                         'coquelicot', 'flocq', 'lf', 'plf', 'cpdt', 'color' ],
+            init_import: [],
             file_dialog: false,
             coq:       { /* Coq option values */ },
             editor:    { /* codemirror options */ }
@@ -648,7 +649,11 @@ class CoqManager {
         let init_opts = {implicit_libs: this.options.implicit_libs, stm_debug: false,
                          coq_options: this._parseOptions(this.options.coq || {})},
             load_path = this.packages.getLoadPath(),
-            load_lib = this.options.prelude ? [["Coq", "Init", "Prelude"]] : [];
+            load_lib = this.options.prelude ? [PKG_ALIASES.prelude] : [];
+
+        for (let pkg of this.options.init_import || []) {
+            load_lib.push(PKG_ALIASES[pkg] || pkg.split('.'));
+        }
 
         this.coq.init(init_opts, load_lib, load_path);
         // Almost done!
@@ -1109,6 +1114,11 @@ const Phases = {
     PROCESSING: 'processing', PROCESSED: 'processed',
     ERROR: 'error'
 };
+
+const PKG_ALIASES = {
+    prelude: ["Coq", "Init", "Prelude"],
+    utf8: ["Coq", "Unicode", "Utf8"]
+}
 
 
 class CoqContextualInfo {

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -240,10 +240,11 @@ class CoqManager {
 
         // Default options
         this.options = {
-            prelude: true,
-            debug:   true,
-            show:    true,
-            focus:   true,
+            prelaunch:  false,
+            prelude:    true,
+            debug:      true,
+            show:       true,
+            focus:      true,
             wrapper_id: 'ide-wrapper',
             theme:      'light',
             base_path:   "./",
@@ -271,6 +272,11 @@ class CoqManager {
         this.layout = new CoqLayoutClassic(this.options);
         this.layout.splash();
         this.layout.onAction = this.toolbarClickHandler.bind(this);
+
+        this.layout.onToggle = ev => {
+            if (ev.shown && !this.coq) this.launch();
+            if (this.coq) this.layout.onToggle = () => {};
+        };
 
         this.setupDragDrop();
 
@@ -306,8 +312,9 @@ class CoqManager {
         this.error = [];
         this.navEnabled = false;
 
-        // The fun starts: commence loading packages (asynchronously)
-        this.launch();
+        // Launch time
+        if (this.options.prelaunch)
+            this.launch();
 
         if (this.options.show)
             requestAnimationFrame(() => this.layout.show());

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -215,6 +215,8 @@ class CoqManager {
         this.options = {
             prelude: true,
             debug:   true,
+            show:    true,
+            focus:   true,
             wrapper_id: 'ide-wrapper',
             theme:      'light',
             base_path:   "./",
@@ -278,7 +280,8 @@ class CoqManager {
         // Display packages panel:
         this.packages.expand();
 
-        requestAnimationFrame(() => this.layout.show());
+        if (this.options.show)
+            requestAnimationFrame(() => this.layout.show());
 
         // This is a sid-based index of processed statements.
         this.doc = {
@@ -984,7 +987,9 @@ class CoqManager {
     enable() {
         this.navEnabled = true;
         this.layout.toolbarOn();
-        this.provider.focus();
+        if (this.options.focus) {
+            this.provider.focus();
+        }
     }
 
     // Disable the IDE.

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -62,13 +62,16 @@ class ProviderContainer {
         // Create sub-providers
         for (let element of this.findElements(elementRefs)) {
 
+            if (this.options.replace)
+                element = Deprettify.trim(element);
+
             // Init.
-            var cm = new CmCoqProvider(e, this.options.editor);
+            var cm = new CmCoqProvider(element, this.options.editor, this.options.replace);
             cm.idx = idx++;
             this.snippets.push(cm);
 
             // Track focus XXX (make generic)
-            cm.editor.on('focus', evt => { this.currentFocus = cm; });
+            cm.editor.on('focus', ev => { this.currentFocus = cm; });
 
             // Track invalidate
             cm.onInvalidate = stm       => { this.onInvalidate(stm); };

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -245,6 +245,7 @@ class CoqManager {
             debug:      true,
             show:       true,
             focus:      true,
+            replace:    false,
             wrapper_id: 'ide-wrapper',
             theme:      'light',
             base_path:   "./",
@@ -704,7 +705,7 @@ class CoqManager {
 
     /**
      * Creates a JSON-able version of the startup Coq options.
-     * E.g. {'Default Timeout': 10}  -->  [[['Default'm 'Timeout'], ['IntValue', 10]]]
+     * E.g. {'Default Timeout': 10}  -->  [[['Default', 'Timeout'], ['IntValue', 10]]]
      * @param {object} coq_options option name to value dictionary
      */
     _parseOptions(coq_options) {

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -82,8 +82,10 @@ class ProviderContainer {
                 cm.onTipOut   = ()             => { this.onTipOut(); }
 
                 // Running line numbers
-                if (idx > 0) this.renumber(idx - 1);
-                cm.onResize = () => { this.renumber(idx); }
+                if (this.options.line_numbers === 'continue') {
+                    if (idx > 0) this.renumber(idx - 1);
+                    cm.onResize = () => { this.renumber(idx); }
+                }
 
                 await this.yield();
             }
@@ -257,6 +259,7 @@ class CoqManager {
                         'coquelicot', 'flocq', 'lf', 'plf', 'cpdt', 'color' ],
             init_import: [],
             file_dialog: false,
+            line_numbers: 'continue',
             coq:       { /* Coq option values */ },
             editor:    { /* codemirror options */ }
             // Disabled on 8.6

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -42,7 +42,7 @@ if (typeof navigator !== 'undefined')
 /***********************************************************************/
 class ProviderContainer {
 
-    constructor(elms, options) {
+    constructor(elementRefs, options) {
 
         this.options = options ? options : {};
 
@@ -59,8 +59,8 @@ class ProviderContainer {
         this.onTipHover = (completion, zoom) => {};
         this.onTipOut = () => {};
 
-        // for (e of elms) not very covenient here due to the closure.
-        elms.forEach(e => {
+        // Create sub-providers
+        for (let element of this.findElements(elementRefs)) {
 
             // Init.
             var cm = new CmCoqProvider(e, this.options.editor);
@@ -77,7 +77,21 @@ class ProviderContainer {
 
             cm.onTipHover = (entity, zoom) => { this.onTipHover(entity, zoom); };
             cm.onTipOut   = ()             => { this.onTipOut(); }
-        });
+        }
+    }
+
+    findElements(elementRefs) {
+        var elements = [];
+        for (let e of elementRefs) {
+            var els = (typeof e === 'string') ? 
+                [document.getElementById(e), ...document.querySelectorAll(e)] : e;
+            els = els.filter(x => x);
+            if (els.length === 0) {
+                console.warn(`[jsCoq] element(s) not found: '${e}'`);
+            }
+            elements.push(...els);
+        }
+        return elements;
     }
 
     // Get the next candidate and mark it.


### PR DESCRIPTION
This has been in the works for some time and I think it's time it should be merged. It contains a bunch of things I did to be able to inject jsCoq in Software Foundations pages more cleanly. Mostly some CSS fixes so that jsCoq's styles don't interfere with ones on the page; and also the running line numbering across snippets.

The `Deprettify` class is used to convert `coqdoc` generated code blocks back to valid Coq code.