### PR TITLE
Package archive drop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
    `replace`, and `init_import` (@corwin-of-amber)
  - Line numbers continue across code snippets on the same page. Useful
    for `coqdoc`-generated pages (@corwin-of-amber)
+ - Accept dropped `.coq-pkg` files as packages to add to the current
+   session (@corwin-of-amber)
 
  - [ ] Automatic parsing mode.
  - [ ] Execution gutters.

--- a/ui-js/coq-manager.js
+++ b/ui-js/coq-manager.js
@@ -374,8 +374,12 @@ class CoqManager {
             // TODO better check file type and size before
             //  opening
             var file = evt.originalEvent.dataTransfer.files[0];
-            if (file)
-                this.provider.openFile(file);
+            if (file) {
+                if (file.name.match(/[.](coq-pkg|zip)$/))
+                    this.packages.dropPackage(file);
+                else
+                    this.provider.openFile(file);
+            }
         });
     }
 

--- a/ui-js/coq-packages.js
+++ b/ui-js/coq-packages.js
@@ -78,6 +78,9 @@ class PackageManager {
         return archive.getPackageInfo().then(pi => {
             bname = bname || pi.desc;
 
+            if (!bname) throw new Error('invalid archive: missing package manifest (coq-pkg.json)');
+            if (this.bundles[bname]) throw new Error(`package ${bname} is already present`);
+
             for (let k in pi)
                 if (!pkg_info[k]) pkg_info[k] = pi[k];
 
@@ -247,7 +250,8 @@ class PackageManager {
         this.addBundleZip(undefined, file).then(bundle => {
             bundle.div.scrollIntoViewIfNeeded();
             this.startPackageDownload(bundle.info.desc);
-        });
+        })
+        .catch(err => { alert(`${file.name}: ${err}`); });
     }
 
     onBundleStart(bname) {


### PR DESCRIPTION
Accepts dropped `.coq-pkg` files, and immediately downloads the dropped package and its dependencies.

I've tested it with the lemma overloading package (https://github.com/coq-community/lemma-overloading) suggested by @palmskog.

[lemma-overloading.zip](https://github.com/ejgallego/jscoq/files/4174149/lemma-overloading.zip)

